### PR TITLE
Fix Dagster asset selection definitions

### DIFF
--- a/src/hubeau_pipeline/jobs/analytics.py
+++ b/src/hubeau_pipeline/jobs/analytics.py
@@ -8,8 +8,8 @@ from dagster import define_asset_job, AssetSelection
 analytics_production_job = define_asset_job(
     name="analytics_production_job",
     description="🔗 Analytics Production: SOSA + Analyses basées sur données réelles",
-    selection=AssetSelection.keys([
+    selection=AssetSelection.keys(
         "sosa_ontology_production",
         "integrated_analytics_production"
-    ])
+    )
 )

--- a/src/hubeau_pipeline/jobs/ingestion.py
+++ b/src/hubeau_pipeline/jobs/ingestion.py
@@ -8,46 +8,46 @@ from dagster import define_asset_job, AssetSelection
 hubeau_production_job = define_asset_job(
     name="hubeau_production_job",
     description="🌊 Hub'Eau Production: APIs → MinIO → TimescaleDB (optimisé)",
-    selection=AssetSelection.keys([
+    selection=AssetSelection.keys(
         # Bronze - Ingestion avec retry/pagination
         "hubeau_piezo_bronze",
-        "hubeau_hydro_bronze", 
+        "hubeau_hydro_bronze",
         "hubeau_quality_surface_bronze",
         "hubeau_quality_groundwater_bronze",
         "hubeau_temperature_bronze",
-        
+
         # Silver - Chargement optimisé TimescaleDB
         "piezo_timescale_optimized",
         "quality_timescale_optimized"
-    ])
+    )
 )
 
 # Job BDLISA : WFS → MinIO → PostGIS
 bdlisa_production_job = define_asset_job(
     name="bdlisa_production_job",
     description="🗺️ BDLISA Production: WFS → MinIO → PostGIS",
-    selection=AssetSelection.keys([
+    selection=AssetSelection.keys(
         "bdlisa_geographic_bronze",
         "bdlisa_postgis_silver"
-    ])
+    )
 )
 
 # Job Sandre : API → MinIO → Neo4j  
 sandre_production_job = define_asset_job(
     name="sandre_production_job",
     description="📚 Sandre Production: API → MinIO → Neo4j",
-    selection=AssetSelection.keys([
+    selection=AssetSelection.keys(
         "sandre_thesaurus_bronze",
         "sandre_neo4j_silver"
-    ])
+    )
 )
 
 # Job Démonstration (simulations pour interface)
 demo_showcase_job = define_asset_job(
     name="demo_showcase_job",
     description="🎭 Démonstration: Assets simulés pour interface",
-    selection=AssetSelection.keys([
+    selection=AssetSelection.keys(
         "demo_quality_scores",
         "demo_neo4j_showcase"
-    ])
+    )
 )


### PR DESCRIPTION
## Summary
- update ingestion and analytics jobs to pass asset keys as individual arguments to `AssetSelection.keys`
- ensure Dagster asset jobs reference existing asset definitions correctly

## Testing
- pytest *(fails: missing optional dependencies `pandas` and `dagster` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d521b55478832788bf6b72b2dd6320