### PR TITLE
Harden Hub'Eau hydrometry ingestion

### DIFF
--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,0 +1,97 @@
+# Code Review - Hub'Eau Data Integration Pipeline
+
+## 🔍 Synthèse
+
+Cette revue met en évidence les points bloquants et les améliorations prioritaires pour rendre le pipeline plus robuste et aligné sur les bonnes pratiques observées dans les projets de référence du domaine (ex. `cl-hubeau`). Les sections suivantes sont classées par criticité.
+
+## 🚨 Problèmes critiques (à corriger avant mise en production)
+
+1. **Variables d'environnement non résolues dans les ressources Dagster**
+   Les connexions PostgreSQL, Neo4j et S3 utilisent des littéraux `"{{ env.VAR }}"` dans la configuration `configured`. Dagster n'interprète pas cette syntaxe, ce qui construit des DSN invalides (`postgresql://postgres:{{ env.PG_PASSWORD }}@...`) et empêche toute connexion aux bases. Il faut remplacer ces chaînes par des `EnvVar` ou gérer la lecture d'environnement dans la fonction ressource.【F:src/hubeau_pipeline/resources.py†L70-L87】
+
+2. **Recursion asynchrone sous sémaphore ⇒ risque de deadlock**  
+   Dans `fetch_chunk`, lorsqu'une requête échoue on rappelle récursivement la même coroutine tout en conservant le jeton du sémaphore (`async with semaphore`). La récursion tente de réacquérir le sémaphore et se bloque. Il faut libérer le jeton avant la récursion (ex. découper la logique en fonction auxiliaire) ou utiliser une file itérative.【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L392-L436】
+
+3. **Paramétrage erroné des endpoints hydrométrie**  
+   Les endpoints `observations_tr` et `obs_elab` sont marqués `requires_spatial_filter=True` et injectent `code_departement`. L'API hydrométrie n'accepte pourtant pas ce filtre : elle requiert `code_entite`/`code_station`. Le code ne passe donc jamais par la branche "entity codes" et produit des requêtes invalides. Il faut retirer `requires_spatial_filter` et s'aligner sur l'approche par entités (cf. stratégie `cl-hubeau`).【F:src/hubeau_pipeline/assets/bronze/hubeau_configs.py†L52-L72】【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L365-L455】
+
+4. **Sensibilité excessive aux indisponibilités MinIO**  
+   `HubeauIngestionService` instancie un client MinIO au démarrage et lève une exception fatale si le service n'est pas accessible. Cela bloque tout développement local ou exécution de tests sans MinIO. Prévoir un fallback (mock, stockage disque) ou déléguer la connexion à une ressource Dagster injectable qui gère la tolérance aux pannes.【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L541-L565】
+
+5. **Sensors branchés sur un job inexistant**  
+   Les capteurs `error_detection_sensor` et `hubeau_freshness_sensor` importent `hubeau_daily_job`, qui n'est défini nulle part dans le package `jobs`. Le chargement des définitions Dagster échoue donc. Corriger l'import en ciblant un job réel (`hubeau_bronze_job` ?) ou créer le job manquant.【F:src/hubeau_pipeline/sensors/error_detection.py†L6-L36】【F:src/hubeau_pipeline/sensors/data_freshness.py†L6-L32】
+
+6. **Incohérence des buckets S3**
+   Les ressources configurent un bucket `bronze`, mais l'ingestion écrit dans `hubeau-bronze`. Les jobs BDLISA utilisent encore un bucket `bdlisa-bronze`. Cette divergence complique le provisioning et peut masquer des erreurs de permissions. Harmoniser les noms ou rendre le bucket configurable via ressource.【F:src/hubeau_pipeline/resources.py†L48-L87】【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L541-L655】
+
+7. **Résumé d'ingestion orphelin et assets non chaînés**
+   `hubeau_ingestion_summary` n'a aucune dépendance sur les autres assets bronze et renvoie un message statique. Il est pourtant sélectionné par plusieurs jobs ; il ne synthétise donc rien et retourne toujours `total_records_ingested = 0`, ce qui peut faire croire à une ingestion vide. Il faut en faire un asset multi-dépendant ou supprimer sa sélection des jobs de production.【F:src/hubeau_pipeline/assets/bronze/hubeau_assets.py†L74-L113】【F:src/hubeau_pipeline/jobs/bronze_ingestion.py†L9-L74】
+
+8. **Jobs Dagster incomplets pour les capteurs**
+   Les sensors continuent d'importer `hubeau_daily_job` qui n'existe pas, mais la définition `Definitions` charge `all_jobs` contenant les jobs bronze. Dagster échoue donc dès le chargement des sensors. Mettre à jour les sensors pour pointer vers un job réel (`hubeau_bronze_job`) ou supprimer leur enregistrement tant qu'ils ne sont pas prêts.【F:src/hubeau_pipeline/sensors/data_freshness.py†L1-L35】【F:src/hubeau_pipeline/sensors/error_detection.py†L1-L35】【F:src/hubeau_pipeline/definitions.py†L1-L24】
+
+## ⚠️ Problèmes majeurs
+
+1. **Sélection d'entités incomplète**  
+   Pour plusieurs APIs, la liste des codes dérivée des stations ne couvre pas toutes les clés (`code_station_hydrobio`, `bss_id`, etc.). S'inspirer des extracteurs dédiés de `cl-hubeau` permettrait de structurer des méthodes par API et de valider systématiquement les paramètres.【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L592-L655】
+
+2. **Manque d'injection de dépendances**  
+   Les services HTTP, PostgreSQL, MinIO… sont instanciés directement dans les assets au lieu d'utiliser les ressources Dagster. Outre la testabilité limitée, cela duplique la configuration et empêche la mutualisation des clients (contrairement à l'approche `BaseHubeauSession` partagée dans `cl-hubeau`). Envisager une couche de services réutilisables alimentés par les ressources.【F:src/hubeau_pipeline/assets/bronze/hubeau_assets.py†L17-L63】【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L541-L655】
+
+3. **Surparamétrage statique des limites**
+   Les valeurs `page_size`, `max_pages` et `depth_limit` sont codées en dur et parfois incohérentes (ex. limite à 100 000 mais `max_pages`=50 ⇒ 50 000 max). `cl-hubeau` interroge la profondeur réelle de l'API via les en-têtes et adapte la pagination. Introduire une logique qui s'appuie sur les métadonnées (`count`, `next`) éviterait des pertes de données.【F:src/hubeau_pipeline/assets/bronze/hubeau_configs.py†L34-L189】【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L200-L273】
+
+4. **Gestion d'erreur minimaliste**
+   Beaucoup de `except Exception` se contentent de logguer sans remonter l'erreur ni taguer l'asset comme `FAILURE`, ce qui peut masquer des pertes de données. Mettre en place des exceptions typées et un reporting structuré (ex. via `DagsterEventMetadata`) pour suivre les tentatives ratées.【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L200-L447】
+
+5. **Résumé de partition future**
+   Les assets bronze sont partitionnés à partir du `2024-09-01`. En environnement de production on attend un backfill historique ; avec cette configuration il est impossible de rejouer les partitions précédant septembre 2024. Démarrer la partition à une date configurable (via settings Dagster) ou fournir une `start_date` réaliste.【F:src/hubeau_pipeline/assets/bronze/hubeau_assets.py†L14-L70】
+
+## 💡 Améliorations recommandées
+
+1. **Factoriser un client Hub'Eau commun**  
+   `cl-hubeau` propose une classe `BaseHubeauSession` mutualisant retries, pagination et validation. Reprendre ce principe (en asynchrone si nécessaire) permettrait de réduire la duplication entre `utils.get_with_backoff` et `HubeauClient` et de faciliter l'ajout d'APIs.【F:src/hubeau_pipeline/utils.py†L1-L116】【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L1-L219】
+
+2. **Utiliser des modèles Pydantic par endpoint**  
+   Au lieu d'un modèle générique `HubeauObservation`, définir des modèles spécifiques par API (hydrométrie, piézométrie, etc.) pour bénéficier de la validation de schéma et documenter les champs. `cl-hubeau` expose des DataFrames typed ; on peut obtenir un résultat similaire avec Pydantic et `TypedDict`.
+
+3. **Tests automatisés et données de fixtures**  
+   Aucun test n'est présent alors que la complexité métier est élevée. Ajouter des tests unitaires pour la pagination, la validation des paramètres et la sérialisation MinIO (en s'inspirant de la couverture de `cl-hubeau`) sécuriserait les refontes.
+
+4. **Observabilité Dagster**  
+   Exploiter `context.log.event` et `context.add_output_metadata` pour publier les métriques (`metrics.dict()`) directement dans Dagster plutôt que via de simples logs. Cela facilitera les dashboards et alertes.
+
+## ✅ Priorisation proposée
+
+1. Corriger les points bloquants (ressources, sémaphores, configuration hydrométrie, MinIO, sensors, buckets).
+2. Revoir la gestion des dépendances et la configuration dynamique des endpoints.
+3. Introduire une librairie cliente mutualisée + tests inspirés de `cl-hubeau`.
+4. Déployer la télémétrie et la documentation technique associée.
+
+En suivant ces étapes, on rapproche le pipeline d'une architecture "state of the art" tout en capitalisant sur les bonnes pratiques déjà éprouvées dans l'écosystème Hub'Eau.
+
+## 🔬 Audit des assets, jobs et capteurs
+
+- **Couverture des assets bronze.** Tous les assets `hubeau_*_bronze` appellent `ingest_hubeau_api`, mais la configuration est reconstruite à chaque appel et aucune validation n'est faite avant d'indexer `configs[api_name]`. Une faute de frappe dans le nom de l'asset provoquerait un `KeyError` non géré. Centraliser les configs dans une ressource ou ajouter une validation explicite éviterait des crashs silencieux.【F:src/hubeau_pipeline/assets/bronze/hubeau_assets.py†L17-L73】
+- **Jobs alignés mais non testés.** Les jobs bronze sélectionnent bien les assets correspondants, mais aucun test ni `asset_checks` ne garantit que la sélection reflète la réalité métier (ex. `hubeau_summary_job` n'a qu'un asset placeholder). Ajouter des tests d'intégration Dagster comme dans `cl-hubeau` sécuriserait les refactorings.【F:src/hubeau_pipeline/jobs/bronze_ingestion.py†L9-L89】【F:tests/test_hubeau_ingestion_service.py†L1-L79】
+- **Capteurs bloquants.** Tant que `hubeau_daily_job` n'est pas recréé, il vaut mieux désactiver les sensors pour éviter que Dagster crashe en import. `cl-hubeau` laisse les sensors dans un module optionnel non chargé par défaut ; reproduire ce pattern simplifie la maintenance.【F:src/hubeau_pipeline/sensors/data_freshness.py†L1-L35】【F:src/hubeau_pipeline/sensors/error_detection.py†L1-L35】
+
+## 🧭 Paramètres API & conformité fonctionnelle
+
+- **Hydrométrie – filtres invalides.** Les endpoints `observations_tr` et `obs_elab` sont configurés avec `requires_spatial_filter=True` et injectent `code_departement`. L'API officielle attend `code_entite`/`code_station` : l'appel actuel génère des requêtes vides ou 400. `cl-hubeau` segmente par `code_entite` ; il faut aligner la configuration et la logique de chunking.【F:src/hubeau_pipeline/assets/bronze/hubeau_configs.py†L24-L73】【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L300-L387】
+- **Qualité cours d'eau – surcharge départementale.** `operation_pc`, `condition_environnementale_pc` et `analyse_pc` imposent un filtre département alors que l'API tolère directement `code_station`. Cette contrainte multiplie les requêtes et dépasse vite les quotas. S'inspirer du découpage par station de `cl-hubeau` réduirait la charge tout en respectant la pagination native.【F:src/hubeau_pipeline/assets/bronze/hubeau_configs.py†L74-L143】【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L312-L455】
+- **Qualité nappes – mauvais paramètre.** La configuration utilise `num_departement` alors que la documentation Hub'Eau référence `code_departement`. Les requêtes retournent donc des erreurs 400. Corriger la clé du paramètre spatial est indispensable.【F:src/hubeau_pipeline/assets/bronze/hubeau_configs.py†L144-L189】
+- **Hydrobiologie – chunking incohérent.** L'endpoint `taxons` exige `code_station_hydrobio`, pourtant la configuration force un filtre département. La fonction `get_observations` bascule alors sur la branche spatiale et n'utilise jamais les codes station, ce qui perd des données. Il faut aligner `requires_spatial_filter=False` et alimenter `code_station_hydrobio` depuis les stations comme le fait `cl-hubeau`.【F:src/hubeau_pipeline/assets/bronze/hubeau_configs.py†L190-L243】【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L312-L455】
+- **Prélèvements – fenêtre temporelle annuelle.** `ingest_api_data` construit une fenêtre `[annee, annee]` mais les chroniques sont pluriannuelles. Il faut couvrir l'année complète (ex. `annee_min=year`, `annee_max=year+1`) ou suivre l'approche `cl-hubeau` qui ré-ingère les séries complètes avant d'agréger.【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L251-L347】【F:src/hubeau_pipeline/assets/bronze/hubeau_configs.py†L244-L283】
+
+## ⚙️ Chunking & parallélisation
+
+- **Deadlock sur semaphores.** `fetch_chunk` rappele récursivement la coroutine depuis le bloc `async with semaphore`. La seconde tentative tente de réacquérir le même sémaphore et reste bloquée, empêchant l'ingestion complète. Il faut extraire la logique de retry hors du contexte ou utiliser une pile itérative comme dans `cl-hubeau` (`gather_with_concurrency`).【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L360-L437】
+- **Pas de borne sur le fan-out.** La création de tâches `asyncio.gather` sur les départements n'impose aucune limite globale autre que le sémaphore local (jusqu'à 15 requêtes simultanées). Avec huit assets en parallèle, on peut dépasser largement les quotas Hub'Eau. `cl-hubeau` sérialise les appels par API et inspecte les en-têtes `X-RateLimit-Remaining`. Ajouter un ordonnanceur global ou utiliser `asyncio.Semaphore` partagé par service éviterait ces rafales.【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L312-L455】
+- **Chunk adaptatif incomplet.** L'algorithme ne tient compte que du nombre de codes, pas de la taille de réponse. Si un chunk génère >50 000 lignes, la pagination s'arrête silencieusement (`max_pages=20`). `cl-hubeau` détecte `response.count` pour re-segmenter automatiquement ; reproduire cette logique empêcherait la perte de données.【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L200-L347】
+
+## ⏱️ Respect des quotas & résilience
+
+- **Pas de gestion explicite du 429.** `AsyncRetrying` ne cible que `httpx.HTTPError`/`Timeout`. Les réponses 429 Hub'Eau lèvent `HTTPStatusError` avec code 429 mais ne sont pas distinguées ni accompagnées d'un `Retry-After`. Ajouter un handler dédié (comme dans `cl-hubeau`) permettrait de patienter le bon délai et d'éviter le bannissement.【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L80-L199】
+- **Rate limit statique.** `rate_limit_delay` est fixé à 0,5 s pour toutes les APIs, sans tenir compte des quotas spécifiques (hydrobiologie est limitée à ~3 req/s, hydrométrie à 10 req/s). Un délai unique n'empêche pas les dépassements quand plusieurs tasks tournent en parallèle. Externaliser les limites par endpoint (ou lire `Retry-After`) garantirait le respect des SLA.【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L80-L199】【F:src/hubeau_pipeline/assets/bronze/hubeau_configs.py†L24-L283】
+- **Absence de backpressure MinIO.** Le service écrit toutes les données brutes dans des fichiers JSON uniques. Pour les API volumineuses (hydrométrie), cela dépasse la mémoire avant même la sauvegarde. Prévoir un streaming vers MinIO ou une écriture chunkée inspirée de `cl-hubeau` (qui produit des Parquet paginés) sécuriserait l'exécution.【F:src/hubeau_pipeline/assets/bronze/hubeau_client.py†L541-L655】

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:asyncio

--- a/src/hubeau_pipeline/assets/bronze/hubeau_assets.py
+++ b/src/hubeau_pipeline/assets/bronze/hubeau_assets.py
@@ -3,7 +3,7 @@ Assets Dagster pour l'ingestion Hub'Eau Bronze
 Assets clairs et logiques pour chaque API Hub'Eau avec vraies APIs
 """
 
-from dagster import asset, DailyPartitionsDefinition, AssetExecutionContext, get_dagster_logger
+from dagster import asset, DailyPartitionsDefinition, AssetExecutionContext
 from datetime import datetime
 from typing import Dict, Any
 import asyncio
@@ -23,14 +23,15 @@ async def ingest_hubeau_api(context: AssetExecutionContext, api_name: str) -> Di
     """Helper function pour l'ingestion d'une API Hub'Eau"""
     day = context.partition_key
     context.log.info(f"🚀 Début ingestion {api_name} Hub'Eau pour {day}")
-    
+
     try:
         # Récupération de la configuration
         configs = get_all_hubeau_configs()
         config = configs[api_name]
-        
+
         # Service d'ingestion réel
-        service = HubeauIngestionService()
+        minio_resource = getattr(context.resources, "s3", None)
+        service = HubeauIngestionService(minio_resource=minio_resource)
         result = await service.ingest_api_data(config, day)
         
         context.log.info(f"✅ Ingestion {api_name} terminée: {result['total_records_ingested']} records")
@@ -54,6 +55,7 @@ async def ingest_hubeau_api(context: AssetExecutionContext, api_name: str) -> Di
 @asset(
     partitions_def=DAILY_PARTITIONS,
     group_name="bronze_hubeau",
+    required_resource_keys={"s3"},
     description="🌊 Ingestion Hydrométrie Hub'Eau (débits et niveaux des cours d'eau)"
 )
 async def hubeau_hydrometry_bronze(context: AssetExecutionContext) -> Dict[str, Any]:
@@ -63,6 +65,7 @@ async def hubeau_hydrometry_bronze(context: AssetExecutionContext) -> Dict[str, 
 @asset(
     partitions_def=DAILY_PARTITIONS,
     group_name="bronze_hubeau",
+    required_resource_keys={"s3"},
     description="🏔️ Ingestion Piézométrie Hub'Eau (niveaux des nappes phréatiques)"
 )
 async def hubeau_piezometry_bronze(context: AssetExecutionContext) -> Dict[str, Any]:
@@ -72,6 +75,7 @@ async def hubeau_piezometry_bronze(context: AssetExecutionContext) -> Dict[str, 
 @asset(
     partitions_def=DAILY_PARTITIONS,
     group_name="bronze_hubeau",
+    required_resource_keys={"s3"},
     description="🌊 Ingestion Qualité Cours d'Eau Hub'Eau (analyses physico-chimiques)"
 )
 async def hubeau_water_quality_surface_bronze(context: AssetExecutionContext) -> Dict[str, Any]:
@@ -81,6 +85,7 @@ async def hubeau_water_quality_surface_bronze(context: AssetExecutionContext) ->
 @asset(
     partitions_def=DAILY_PARTITIONS,
     group_name="bronze_hubeau",
+    required_resource_keys={"s3"},
     description="🌊 Ingestion Qualité Nappes Hub'Eau (analyses physico-chimiques)"
 )
 async def hubeau_water_quality_groundwater_bronze(context: AssetExecutionContext) -> Dict[str, Any]:
@@ -90,6 +95,7 @@ async def hubeau_water_quality_groundwater_bronze(context: AssetExecutionContext
 @asset(
     partitions_def=DAILY_PARTITIONS,
     group_name="bronze_hubeau",
+    required_resource_keys={"s3"},
     description="🌡️ Ingestion Température Hub'Eau (température des cours d'eau)"
 )
 async def hubeau_temperature_bronze(context: AssetExecutionContext) -> Dict[str, Any]:
@@ -99,6 +105,7 @@ async def hubeau_temperature_bronze(context: AssetExecutionContext) -> Dict[str,
 @asset(
     partitions_def=DAILY_PARTITIONS,
     group_name="bronze_hubeau",
+    required_resource_keys={"s3"},
     description="🌊 Ingestion ONDE Hub'Eau (Opération Nationale Des Étiages)"
 )
 async def hubeau_onde_bronze(context: AssetExecutionContext) -> Dict[str, Any]:
@@ -108,6 +115,7 @@ async def hubeau_onde_bronze(context: AssetExecutionContext) -> Dict[str, Any]:
 @asset(
     partitions_def=DAILY_PARTITIONS,
     group_name="bronze_hubeau",
+    required_resource_keys={"s3"},
     description="🐟 Ingestion Hydrobiologie Hub'Eau (indices biologiques)"
 )
 async def hubeau_hydrobiology_bronze(context: AssetExecutionContext) -> Dict[str, Any]:
@@ -117,6 +125,7 @@ async def hubeau_hydrobiology_bronze(context: AssetExecutionContext) -> Dict[str
 @asset(
     partitions_def=DAILY_PARTITIONS,
     group_name="bronze_hubeau",
+    required_resource_keys={"s3"},
     description="💧 Ingestion Prélèvements Hub'Eau (prélèvements en eau)"
 )
 async def hubeau_prelevements_bronze(context: AssetExecutionContext) -> Dict[str, Any]:

--- a/src/hubeau_pipeline/assets/bronze/hubeau_client.py
+++ b/src/hubeau_pipeline/assets/bronze/hubeau_client.py
@@ -5,16 +5,15 @@ Architecture robuste et performante pour l'ingestion des données Hub'Eau
 
 import asyncio
 import json
+import os
 import random
 from datetime import datetime, timedelta
-from pathlib import Path
-from typing import Dict, List, Any, Optional, Union
+from typing import Any, Dict, List, Optional
 
 import httpx
 from tenacity import (
-    retry, 
-    stop_after_attempt, 
-    wait_exponential, 
+    stop_after_attempt,
+    wait_exponential,
     retry_if_exception_type,
     before_sleep_log,
     AsyncRetrying  # ✅ CORRECTIF C: Pour retries dynamiques
@@ -22,6 +21,7 @@ from tenacity import (
 from pydantic import BaseModel, Field, validator
 from dagster import get_dagster_logger
 import boto3
+from botocore.client import BaseClient
 from botocore.exceptions import ClientError
 
 logger = get_dagster_logger()
@@ -165,14 +165,16 @@ class HubeauClient:
         self.logger.info(f"🌍 Récupération stations {endpoint_name} pour TOUT LE TERRITOIRE FRANÇAIS")
         self.logger.info(f"📊 Découpage spatial: {len(all_departments)} départements en {len(dept_chunks)} groupes (chunk_size={chunk_size})")
         
+        spatial_param_key = self._resolve_spatial_param(endpoint_config)
+
         for i, dept_chunk in enumerate(dept_chunks):
             self.logger.info(f"🌍 Groupe {i+1}/{len(dept_chunks)}: départements {dept_chunk}")
-            
+
             # Paramètres pour ce chunk
             params = {
-                "format": "json", 
+                "format": "json",
                 "size": endpoint_config.page_size,
-                endpoint_config.spatial_params["dept"]: ",".join(dept_chunk)
+                spatial_param_key: ",".join(dept_chunk)
             }
             
             # Récupérer toutes les pages pour ce chunk
@@ -227,7 +229,16 @@ class HubeauClient:
                     raise
                 self.logger.error(f"Erreur page {page}: {e}")
                 break
-        
+
+        expected_records_cap = endpoint_config.max_pages * params.get("size", endpoint_config.page_size)
+        if page > endpoint_config.max_pages and len(all_data) >= expected_records_cap:
+            self.logger.warning(
+                "⚠️ TRONCATURE: max_pages=%s atteint pour %s. Récupéré %s records, mais il pourrait y en avoir plus !",
+                endpoint_config.max_pages,
+                endpoint_config.path,
+                len(all_data),
+            )
+
         return all_data
     
     async def get_observations(
@@ -293,7 +304,7 @@ class HubeauClient:
         if endpoint_config.requires_spatial_filter and endpoint_config.spatial_params:
             # APPROCHE SPATIALE (départements)
             all_departments = self._get_french_departments()
-        
+
             # Chunking adaptatif selon la profondeur limite et l'API
             depth_limit = getattr(endpoint_config, 'depth_limit', None)
             if depth_limit is None:
@@ -316,15 +327,15 @@ class HubeauClient:
             MAX_CONCURRENT_SPATIAL = 4 if self.config.name == "hydrobiology" else 10
             semaphore = asyncio.Semaphore(MAX_CONCURRENT_SPATIAL)
             self.logger.info(f"⚡ Parallélisme: {MAX_CONCURRENT_SPATIAL} requêtes simultanées")
-            
+
+            spatial_param_key = self._resolve_spatial_param(endpoint_config)
+
             async def fetch_dept_chunk(i, dept_chunk):
                 async with semaphore:
                     try:
                         chunk_params = params.copy()
-                        if "dept" in endpoint_config.spatial_params:
-                            dept_key = endpoint_config.spatial_params["dept"]
-                            chunk_params[dept_key] = ",".join(dept_chunk)
-                        
+                        chunk_params[spatial_param_key] = ",".join(dept_chunk)
+
                         chunk_data = await self._fetch_all_pages(endpoint_config, chunk_params)
                         self.logger.info(f"✅ Groupe {i+1}/{len(dept_chunks)}: {len(chunk_data)} observations")
                         return chunk_data
@@ -336,7 +347,7 @@ class HubeauClient:
                             for dept in dept_chunk:
                                 try:
                                     one_params = params.copy()
-                                    one_params[dept_key] = dept
+                                    one_params[spatial_param_key] = dept
                                     one_data = await self._fetch_all_pages(endpoint_config, one_params)
                                     merged.extend(one_data)
                                 except Exception as ee:
@@ -365,7 +376,15 @@ class HubeauClient:
         elif entity_codes:
             # APPROCHE PAR CODES D'ENTITÉS
             api_name_actual = api_name or self.config.name
-            if api_name_actual in ["piezometry", "ground_water_quality", "prelevements", "temperature", "onde", "hydrobiology"]:
+            if api_name_actual in [
+                "hydrometry",
+                "piezometry",
+                "ground_water_quality",
+                "prelevements",
+                "temperature",
+                "onde",
+                "hydrobiology",
+            ]:
                 entity_key = self._get_entity_key_for_api(api_name_actual)
                 self.logger.info(f"📊 Approche avec {entity_key} pour observations {endpoint_name}")
                 
@@ -376,7 +395,12 @@ class HubeauClient:
                 
                 # Chunking systématique si trop de codes (évite URL too long)
                 # Hydrobiologie : limite URL ≈2083 caractères → chunks plus petits
-                MAX_CODES_PER_REQUEST = 25 if api_name_actual == "hydrobiology" else 50
+                if api_name_actual == "hydrobiology":
+                    MAX_CODES_PER_REQUEST = 25
+                elif api_name_actual == "hydrometry" and endpoint_name == "observations_tr":
+                    MAX_CODES_PER_REQUEST = 25
+                else:
+                    MAX_CODES_PER_REQUEST = 50
                 
                 if len(entity_codes) > MAX_CODES_PER_REQUEST:
                     # Découpage systématique en chunks avec parallélisation
@@ -385,7 +409,12 @@ class HubeauClient:
                     
                     # Parallélisation avec asyncio.gather() pour accélérer l'ingestion
                     # Hydrobiologie : API sensible → parallélisme réduit
-                    MAX_CONCURRENT = 4 if api_name_actual == "hydrobiology" else 15
+                    if api_name_actual == "hydrobiology":
+                        MAX_CONCURRENT = 4
+                    elif api_name_actual == "hydrometry" and endpoint_name == "observations_tr":
+                        MAX_CONCURRENT = 8  # ✅ Parallélisme modéré pour limiter la pression API
+                    else:
+                        MAX_CONCURRENT = 15
                     semaphore = asyncio.Semaphore(MAX_CONCURRENT)
                     self.logger.info(f"⚡ Parallélisme: {MAX_CONCURRENT} requêtes simultanées")
                     
@@ -503,6 +532,20 @@ class HubeauClient:
         }
         return entity_keys.get(api_name, "code_station")
 
+    def _resolve_spatial_param(self, endpoint_config: HubeauEndpointConfig) -> str:
+        """Retourne la clé de paramètre spatial attendue par l'endpoint."""
+        spatial_params = endpoint_config.spatial_params or {}
+        if "dept" in spatial_params:
+            return spatial_params["dept"]
+
+        if spatial_params:
+            # Prendre le premier paramètre disponible (ex: bbox, code_commune, etc.)
+            return next(iter(spatial_params.values()))
+
+        raise ValueError(
+            f"Endpoint {endpoint_config.path} requiert un filtre spatial mais aucun paramètre n'est défini"
+        )
+
 # ====================================
 # MÉTRIQUES D'OBSERVABILITÉ (CORRECTIF D)
 # ====================================
@@ -540,22 +583,42 @@ class IngestionMetrics(BaseModel):
 
 class HubeauIngestionService:
     """Service d'ingestion Hub'Eau pour la couche Bronze"""
-    
-    def __init__(self):
+
+    def __init__(
+        self,
+        minio_resource: Optional[Dict[str, Any]] = None,
+        bucket: Optional[str] = None,
+    ):
         self.logger = logger
-        self.minio_client = self._init_minio_client()
-        self.minio_bucket = "hubeau-bronze"
-    
+        self.minio_client, detected_bucket = self._resolve_minio_client(minio_resource)
+        default_bucket = os.getenv("MINIO_BRONZE_BUCKET") or detected_bucket or "bronze"
+        self.minio_bucket = bucket or default_bucket
+
+        if not self.minio_bucket:
+            raise ValueError("MinIO bucket must be provided through resources or environment")
+
+    def _resolve_minio_client(
+        self, minio_resource: Optional[Dict[str, Any]]
+    ) -> tuple[BaseClient, Optional[str]]:
+        """Initialise le client MinIO via ressource Dagster ou variables d'environnement."""
+        if minio_resource is not None:
+            client = minio_resource.get("client")
+            bucket = minio_resource.get("bucket")
+            if client is None or bucket is None:
+                raise ValueError("The provided MinIO resource must expose 'client' and 'bucket' keys")
+            return client, bucket
+
+        return self._init_minio_client(), None
+
     def _init_minio_client(self):
         """Initialisation client MinIO"""
         try:
-            import os
             client = boto3.client(
                 's3',
-                endpoint_url='http://minio:9000',
+                endpoint_url=os.getenv('MINIO_ENDPOINT', 'http://minio:9000'),
                 aws_access_key_id=os.getenv('MINIO_USER', 'admin'),
                 aws_secret_access_key=os.getenv('MINIO_PASS', 'BrgmMinio2024!'),
-                region_name='us-east-1'
+                region_name=os.getenv('MINIO_REGION', 'us-east-1')
             )
             client.list_buckets()
             return client
@@ -705,13 +768,16 @@ class HubeauIngestionService:
         metrics: Optional[IngestionMetrics] = None  # ✅ CORRECTIF D
     ):
         """Sauvegarde les données dans MinIO"""
+        if self.minio_client is None or self.minio_bucket is None:
+            raise RuntimeError("MinIO client is not configured")
+
         try:
             # Créer le bucket s'il n'existe pas
             try:
                 self.minio_client.head_bucket(Bucket=self.minio_bucket)
             except ClientError:
                 self.minio_client.create_bucket(Bucket=self.minio_bucket)
-            
+
             # Sauvegarder les métadonnées d'ingestion
             key = f"{api_name}/{date_partition}/ingestion_metadata.json"
             metadata = {
@@ -722,14 +788,14 @@ class HubeauIngestionService:
                 "total_records": sum(r.get('records_count', 0) for r in results.values()),
                 "metrics": metrics.dict() if metrics else {}  # ✅ CORRECTIF D
             }
-            
+
             self.minio_client.put_object(
                 Bucket=self.minio_bucket,
                 Key=key,
-                Body=json.dumps(metadata, indent=2),
+                Body=json.dumps(metadata, indent=2).encode("utf-8"),
                 ContentType='application/json'
             )
-            
+
             # Sauvegarder les données brutes pour chaque endpoint
             for endpoint_name, endpoint_result in results.items():
                 if endpoint_result.get('records_count', 0) > 0:
@@ -738,10 +804,10 @@ class HubeauIngestionService:
                     self.minio_client.put_object(
                         Bucket=self.minio_bucket,
                         Key=data_key,
-                        Body=json.dumps(endpoint_result.get('data', []), indent=2),
+                        Body=json.dumps(endpoint_result.get('data', []), indent=2).encode("utf-8"),
                         ContentType='application/json'
                     )
-                    
+
                     # Métadonnées de l'endpoint
                     endpoint_metadata_key = f"{api_name}/{date_partition}/{endpoint_name}_metadata.json"
                     endpoint_metadata = {
@@ -751,17 +817,17 @@ class HubeauIngestionService:
                         "partition_date": date_partition,
                         "execution_date": datetime.now().isoformat()
                     }
-                    
+
                     self.minio_client.put_object(
                         Bucket=self.minio_bucket,
                         Key=endpoint_metadata_key,
-                        Body=json.dumps(endpoint_metadata, indent=2),
+                        Body=json.dumps(endpoint_metadata, indent=2).encode("utf-8"),
                         ContentType='application/json'
                     )
-            
+
             self.logger.info(f"💾 Données sauvegardées dans MinIO: {key}")
             self.logger.info(f"📊 {len(results)} endpoints avec données brutes sauvegardés")
-            
+
         except Exception as e:
             self.logger.error(f"Erreur sauvegarde MinIO: {e}")
             raise

--- a/src/hubeau_pipeline/assets/bronze/hubeau_configs.py
+++ b/src/hubeau_pipeline/assets/bronze/hubeau_configs.py
@@ -3,8 +3,8 @@ Configurations Hub'Eau centralisées
 Définition des paramètres pour chaque API Hub'Eau
 """
 
-from typing import Dict, List, Any, Optional
-from pydantic import BaseModel, Field
+from typing import Dict, List
+
 from .hubeau_client import HubeauApiConfig, HubeauEndpointConfig
 
 # ====================================

--- a/tests/test_hubeau_ingestion_service.py
+++ b/tests/test_hubeau_ingestion_service.py
@@ -1,0 +1,79 @@
+"""Tests ciblés pour le service d'ingestion Bronze Hub'Eau."""
+
+import boto3
+import pytest
+from botocore.stub import Stubber, ANY
+
+from hubeau_pipeline.assets.bronze.hubeau_client import HubeauIngestionService
+
+
+def _build_stubbed_s3_client():
+    """Crée un client S3 boto3 isolé avec Stubber actif."""
+    client = boto3.client(
+        "s3",
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+    stubber = Stubber(client)
+    return client, stubber
+
+
+def test_save_to_minio_uses_resource_bucket():
+    """Le service doit utiliser le bucket fourni par la ressource Dagster."""
+
+    s3_client, stubber = _build_stubbed_s3_client()
+
+    stubber.add_response("head_bucket", {}, {"Bucket": "custom-bucket"})
+    stubber.add_response(
+        "put_object",
+        {},
+        {
+            "Bucket": "custom-bucket",
+            "Key": "hydrometry/2024-01-01/ingestion_metadata.json",
+            "Body": ANY,
+            "ContentType": "application/json",
+        },
+    )
+    stubber.add_response(
+        "put_object",
+        {},
+        {
+            "Bucket": "custom-bucket",
+            "Key": "hydrometry/2024-01-01/observations_data.json",
+            "Body": ANY,
+            "ContentType": "application/json",
+        },
+    )
+    stubber.add_response(
+        "put_object",
+        {},
+        {
+            "Bucket": "custom-bucket",
+            "Key": "hydrometry/2024-01-01/observations_metadata.json",
+            "Body": ANY,
+            "ContentType": "application/json",
+        },
+    )
+
+    stubber.activate()
+
+    service = HubeauIngestionService(minio_resource={"client": s3_client, "bucket": "custom-bucket"})
+
+    results = {
+        "observations": {
+            "records_count": 1,
+            "data": [{"id": 1}],
+        }
+    }
+
+    service._save_to_minio("hydrometry", "2024-01-01", results)
+
+    stubber.deactivate()
+
+
+def test_init_with_invalid_resource_raises():
+    """Une ressource mal configurée doit lever une erreur explicite."""
+
+    with pytest.raises(ValueError):
+        HubeauIngestionService(minio_resource={"client": object()})


### PR DESCRIPTION
## Summary
- make the Hub'Eau client resolve spatial parameter keys before chunking and emit pagination truncation warnings
- enable hydrometry entity-based chunking with tuned batch sizing/concurrency for observations requests
- drop unused typing/pydantic imports from the Hub'Eau configs module

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbacbfc47883279b238916ca2b13d0