### PR TITLE
Improve Hub'Eau ingestion error handling and tests

### DIFF
--- a/scripts/test_hydrobio_fixes.py
+++ b/scripts/test_hydrobio_fixes.py
@@ -1,162 +1,128 @@
-#!/usr/bin/env python
-"""
-Script de test pour valider les correctifs API Hydrobiologie
-Vérifie que tous les départements sont bien traités et que le split binaire fonctionne
-"""
+"""Tests de régression ciblés pour l'API Hydrobiologie."""
 
 import asyncio
 import sys
-from datetime import datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import List
 
-# Ajouter le chemin src au PYTHONPATH
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+import pytest
 
-from hubeau_pipeline.assets.bronze.hubeau_client import HubeauClient, HubeauIngestionService
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from hubeau_pipeline.assets.bronze.hubeau_client import (
+    HubeauApiResponse,
+    HubeauClient,
+    HubeauPageFetchError,
+)
 from hubeau_pipeline.assets.bronze.hubeau_configs import get_hydrobiology_config
 
-async def test_stations_coverage():
-    """Test A : Vérifier que tous les départements sont traités sans troncature"""
-    print("\n" + "="*80)
-    print("TEST A : Couverture départements (stations_hydrobio)")
-    print("="*80)
-    
-    config = get_hydrobiology_config()
-    
-    async with HubeauClient(config) as client:
-        stations = await client.get_stations("stations_hydrobio")
-        
-        # Extraire les départements uniques
-        depts = set(s.get("code_departement") for s in stations if s.get("code_departement"))
-        
-        print(f"\n✅ Total stations récupérées: {len(stations)}")
-        print(f"✅ Départements couverts: {len(depts)}/101")
-        print(f"✅ Métriques: {client.metrics.dict()}")
-        
-        # Vérifications
-        assert len(stations) > 10000, f"Troncature détectée ! Seulement {len(stations)} stations"
-        assert client.metrics.departements_traites == 101, f"Tous les départements doivent être traités ! Seulement {client.metrics.departements_traites}"
-        
-        print(f"\n✅ TEST A RÉUSSI : {len(stations)} stations, {len(depts)} départements")
-        return stations
 
-async def test_chunk_splitting():
-    """Test B : Vérifier que le split binaire fonctionne en cas d'erreur"""
-    print("\n" + "="*80)
-    print("TEST B : Split binaire en cas d'erreur (simulation)")
-    print("="*80)
-    
-    config = get_hydrobiology_config()
-    
-    # Test avec une petite fenêtre temporelle (7 jours)
-    date_partition = (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d")
-    
-    async with HubeauClient(config) as client:
-        # Récupérer stations pour test
-        stations = await client.get_stations("stations_hydrobio")
-        station_codes = [s.get("code_station_hydrobio") for s in stations[:100]]  # Limiter à 100 pour test rapide
-        
-        # Test observations avec codes
-        observations = await client.get_observations(
-            "indices",
-            station_codes,
-            date_partition,
-            "hydrobiology"
-        )
-        
-        print(f"\n✅ Observations récupérées: {len(observations)}")
-        print(f"✅ Chunks traités: {client.metrics.chunks_total}")
-        print(f"✅ Chunks OK: {client.metrics.chunks_ok}")
-        print(f"✅ Chunks vides: {client.metrics.chunks_vides}")
-        print(f"✅ Chunks échoués: {client.metrics.chunks_echoues}")
-        print(f"✅ Erreurs HTTP 500: {client.metrics.erreurs_http_500}")
-        print(f"✅ Erreurs timeout: {client.metrics.erreurs_timeout}")
-        
-        # Vérification : pas de chunks définitivement échoués
-        if client.metrics.chunks_echoues > 0:
-            print(f"\n⚠️  Codes échoués: {client.metrics.codes_echoues}")
-        
-        print(f"\n✅ TEST B RÉUSSI : {client.metrics.chunks_total} chunks traités")
+def _build_success_response(codes: List[str]) -> HubeauApiResponse:
+    """Crée une réponse simulée contenant les codes fournis."""
 
-async def test_retries_and_metrics():
-    """Test C & D : Vérifier retries dynamiques et métriques"""
-    print("\n" + "="*80)
-    print("TEST C & D : Retries dynamiques + Métriques")
-    print("="*80)
-    
-    config = get_hydrobiology_config()
-    
-    print(f"\n📊 Configuration Hydrobiologie:")
-    print(f"   - max_retries: {config.max_retries}")
-    print(f"   - rate_limit_delay: {config.rate_limit_delay}")
-    print(f"   - depth_limit stations: {config.endpoints['stations_hydrobio'].depth_limit}")
-    
-    assert config.max_retries == 5, "max_retries devrait être 5 pour Hydrobiologie"
-    assert config.rate_limit_delay == 0.6, "rate_limit_delay devrait être 0.6 pour Hydrobiologie"
-    assert config.endpoints['stations_hydrobio'].depth_limit is None, "depth_limit devrait être None"
-    
-    print(f"\n✅ TEST C & D RÉUSSI : Configuration correcte")
+    payload = [
+        {
+            "code_station_hydrobio": code,
+            "date_debut_prelevement": datetime.now(UTC).date().isoformat(),
+        }
+        for code in codes
+    ]
+    return HubeauApiResponse(data=payload, count=len(payload), next=None, previous=None)
 
-async def test_full_ingestion():
-    """Test complet : Ingestion réelle avec synthèse"""
-    print("\n" + "="*80)
-    print("TEST COMPLET : Ingestion avec synthèse")
-    print("="*80)
-    
-    # Date de test (hier)
-    date_partition = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
-    
-    service = HubeauIngestionService()
-    config = get_hydrobiology_config()
-    
-    result = await service.ingest_api_data(config, date_partition)
-    
-    print(f"\n✅ Résultat ingestion:")
-    print(f"   - Status: {result['status']}")
-    print(f"   - Total records: {result['total_records_ingested']}")
-    print(f"   - Endpoints traités: {len(result['results_by_endpoint'])}")
-    
-    if 'metrics' in result:
-        print(f"\n📊 Métriques finales:")
-        for key, value in result['metrics'].items():
-            if isinstance(value, list):
-                print(f"   - {key}: {len(value)} éléments")
-            else:
-                print(f"   - {key}: {value}")
-    
-    print(f"\n✅ TEST COMPLET RÉUSSI")
 
-async def main():
-    """Exécuter tous les tests"""
-    print("\n" + "="*80)
-    print("🧪 TESTS DE VALIDATION - CORRECTIFS HYDROBIOLOGIE")
-    print("="*80)
-    
-    try:
-        # Test A : Couverture départements
-        await test_stations_coverage()
-        
-        # Test B : Split binaire
-        await test_chunk_splitting()
-        
-        # Test C & D : Retries et métriques
-        await test_retries_and_metrics()
-        
-        # Test complet (optionnel, peut être long)
-        # await test_full_ingestion()
-        
-        print("\n" + "="*80)
-        print("✅ TOUS LES TESTS RÉUSSIS !")
-        print("="*80 + "\n")
-        
-    except AssertionError as e:
-        print(f"\n❌ TEST ÉCHOUÉ : {e}")
-        sys.exit(1)
-    except Exception as e:
-        print(f"\n❌ ERREUR : {e}")
-        import traceback
-        traceback.print_exc()
-        sys.exit(1)
+def test_chunk_split_recovers_from_initial_failure(monkeypatch):
+    """Le split binaire doit rejouer les requêtes en cas d'erreur initiale."""
 
-if __name__ == "__main__":
-    asyncio.run(main())
+    async def _run_test():
+        config = get_hydrobiology_config()
+        async with HubeauClient(config) as client:
+            async def fake_make_request(endpoint: str, params):
+                codes = params.get("code_station_hydrobio")
+                if not codes:
+                    return _build_success_response([])
+
+                code_list = codes.split(",")
+                if len(code_list) > 1:
+                    raise RuntimeError("HTTP 500: chunk trop grand")
+
+                return _build_success_response(code_list)
+
+            monkeypatch.setattr(client, "_make_request", fake_make_request)
+
+            station_codes = [f"STATION_{i:03d}" for i in range(30)]
+            observations = await client.get_observations(
+                "indices",
+                station_codes,
+                "2024-01-01",
+                "hydrobiology",
+            )
+
+            assert sorted(obs["code_station_hydrobio"] for obs in observations) == station_codes
+            assert client.metrics.chunks_ok == len(station_codes)
+            assert client.metrics.chunks_echoues == 0
+            assert client.metrics.chunks_total > len(station_codes)
+
+    asyncio.run(_run_test())
+
+
+def test_chunk_split_tracks_failing_codes(monkeypatch):
+    """Les codes fautifs doivent être tracés lorsque même le split échoue."""
+
+    async def _run_test():
+        config = get_hydrobiology_config()
+        async with HubeauClient(config) as client:
+            async def fake_make_request(endpoint: str, params):
+                codes = params.get("code_station_hydrobio")
+                if not codes:
+                    return _build_success_response([])
+
+                code_list = codes.split(",")
+                if len(code_list) > 1:
+                    raise RuntimeError("HTTP 500: chunk trop grand")
+
+                code = code_list[0]
+                if code == "STATION_010":
+                    raise RuntimeError("timeout station 10")
+
+                return _build_success_response([code])
+
+            monkeypatch.setattr(client, "_make_request", fake_make_request)
+
+            station_codes = [f"STATION_{i:03d}" for i in range(30)]
+            observations = await client.get_observations(
+                "indices",
+                station_codes,
+                "2024-01-01",
+                "hydrobiology",
+            )
+
+            expected = [code for code in station_codes if code != "STATION_010"]
+            assert sorted(obs["code_station_hydrobio"] for obs in observations) == expected
+            metrics_snapshot = client.metrics.model_dump()
+            assert client.metrics.chunks_ok == len(expected), metrics_snapshot
+            assert client.metrics.chunks_echoues == 1, metrics_snapshot
+            assert client.metrics.codes_echoues == ["STATION_010"], metrics_snapshot
+
+    asyncio.run(_run_test())
+
+
+def test_fetch_all_pages_raises_when_first_page_fails(monkeypatch):
+    """Une erreur réseau doit remonter jusqu'au service d'ingestion."""
+
+    async def _run_test():
+        config = get_hydrobiology_config()
+        endpoint = config.endpoints["indices"]
+
+        async with HubeauClient(config) as client:
+            async def failing_request(endpoint_name: str, params):
+                raise RuntimeError("backend indisponible")
+
+            monkeypatch.setattr(client, "_make_request", failing_request)
+
+            with pytest.raises(HubeauPageFetchError) as excinfo:
+                await client._fetch_all_pages(endpoint, {"format": "json", "size": endpoint.page_size})
+
+            assert "backend indisponible" in str(excinfo.value)
+
+    asyncio.run(_run_test())

--- a/src/hubeau_pipeline/assets/bronze/hubeau_client.py
+++ b/src/hubeau_pipeline/assets/bronze/hubeau_client.py
@@ -35,6 +35,26 @@ logger = get_dagster_logger()
 GLOBAL_HUBEAU_SEMAPHORE = asyncio.Semaphore(10)  # Max 10 requêtes simultanées TOUS CLIENTS CONFONDUS
 
 # ====================================
+# EXCEPTIONS SPÉCIFIQUES
+# ====================================
+
+
+class HubeauPageFetchError(RuntimeError):
+    """Erreur levée lorsqu'une page Hub'Eau ne peut pas être récupérée."""
+
+    def __init__(self, endpoint: str, page: int, params: Dict[str, Any], original: Exception):
+        redacted_params = {k: v for k, v in params.items() if k != "page"}
+        message = (
+            f"Echec de récupération de la page {page} pour '{endpoint}' "
+            f"avec paramètres {redacted_params}: {original}"
+        )
+        super().__init__(message)
+        self.endpoint = endpoint
+        self.page = page
+        self.params = redacted_params
+        self.original = original
+
+# ====================================
 # MODÈLES PYDANTIC POUR VALIDATION
 # ====================================
 
@@ -217,9 +237,9 @@ class HubeauClient:
         return all_data
     
     async def _fetch_all_pages(
-        self, 
-        endpoint_config, 
-        params: Dict[str, Any], 
+        self,
+        endpoint_config,
+        params: Dict[str, Any],
         bubble_exceptions: bool = False  # ✅ CORRECTIF B: paramètre pour propager exceptions
     ) -> List[Dict[str, Any]]:
         """Helper pour récupérer toutes les pages d'un endpoint"""
@@ -245,12 +265,19 @@ class HubeauClient:
                 
                 page += 1
                 
-            except Exception as e:
-                # ✅ CORRECTIF B: Propager exception si demandé (pour split binaire)
+            except Exception as exc:
+                self.logger.exception(
+                    "Erreur lors de la récupération de la page %s pour %s",
+                    page,
+                    endpoint_config.path,
+                )
+
+                error = HubeauPageFetchError(endpoint_config.path, page, page_params, exc)
+
                 if bubble_exceptions:
-                    raise
-                self.logger.error(f"Erreur page {page}: {e}")
-                break
+                    raise error from exc
+
+                raise error from exc
 
         # Warning de troncature seulement si max_pages défini
         if endpoint_config.max_pages is not None:
@@ -905,12 +932,14 @@ class HubeauIngestionService:
         """Ingestion complète d'une API Hub'Eau"""
         self.logger.info(f"Ingestion {config.name} pour {partition_key or date_partition}")
         
-        results = {}
+        results: Dict[str, Any] = {}
         total_records = 0
-        
+        errors: List[str] = []
+        metrics_snapshot: Optional[IngestionMetrics] = None
+
         async with HubeauClient(config) as client:
             stations = []  # Initialiser stations
-            
+
             # Récupérer les stations
             stations_endpoint = self._get_stations_endpoint(config)
             if stations_endpoint:
@@ -923,7 +952,9 @@ class HubeauIngestionService:
                     }
                     total_records += len(stations)
                 except Exception as e:
-                    self.logger.error(f"Erreur stations {stations_endpoint}: {e}")
+                    message = f"Erreur stations {stations_endpoint}: {e}"
+                    self.logger.error(message)
+                    errors.append(message)
             
             # Récupérer les observations
             observations_endpoints = self._get_observations_endpoints(config)
@@ -980,27 +1011,44 @@ class HubeauIngestionService:
                     total_records += len(observations)
                     
                 except Exception as e:
-                    self.logger.error(f"Erreur observations {endpoint_name}: {e}")
-        
-        # Sauvegarder les données dans MinIO si disponibles
-        if total_records > 0:
-            try:
-                self._save_to_minio(config.name, date_partition, results, client.metrics)
-            except Exception as e:
-                self.logger.warning(f"Erreur sauvegarde MinIO: {e}")
-        
+                    message = f"Erreur observations {endpoint_name}: {e}"
+                    self.logger.error(message)
+                    errors.append(message)
+
+            metrics_snapshot = client.metrics
+
+        # Sauvegarder les données dans MinIO/local même lorsqu'il n'y a pas de données
+        try:
+            self._save_to_minio(config.name, date_partition, results, metrics_snapshot)
+        except Exception as e:
+            warning_message = f"Erreur sauvegarde MinIO: {e}"
+            self.logger.warning(warning_message)
+            errors.append(warning_message)
+
         # ✅ CORRECTIF D: Afficher synthèse métriques
-        if config.name == "hydrobiology":
-            self.logger.info(client.metrics.to_summary())
-        
+        if config.name == "hydrobiology" and metrics_snapshot is not None:
+            self.logger.info(metrics_snapshot.to_summary())
+
+        if errors and total_records == 0:
+            status = 'error'
+        elif errors:
+            status = 'partial_success'
+        elif total_records > 0:
+            status = 'success'
+        else:
+            status = 'no_data'
+
+        metrics_dict = metrics_snapshot.model_dump() if metrics_snapshot is not None else {}
+
         return {
             'execution_date': datetime.now().isoformat(),
             'partition_date': date_partition,
             'api_name': config.name,
             'total_records_ingested': total_records,
             'results_by_endpoint': results,
-            'status': 'success' if total_records > 0 else 'no_data',
-            'metrics': client.metrics.dict() if hasattr(client, 'metrics') else {}  # ✅ CORRECTIF D
+            'status': status,
+            'metrics': metrics_dict,  # ✅ CORRECTIF D
+            'errors': errors,
         }
     
     def _get_stations_endpoint(self, config: HubeauApiConfig) -> Optional[str]:
@@ -1072,7 +1120,7 @@ class HubeauIngestionService:
                 "execution_date": datetime.now().isoformat(),
                 "results_by_endpoint": results,
                 "total_records": sum(r.get('records_count', 0) for r in results.values()),
-                "metrics": metrics.dict() if metrics else {}  # ✅ CORRECTIF D
+                "metrics": metrics.model_dump() if metrics else {}  # ✅ CORRECTIF D
             }
 
             self.minio_client.put_object(
@@ -1139,7 +1187,7 @@ class HubeauIngestionService:
             "execution_date": datetime.now().isoformat(),
             "results_by_endpoint": results,
             "total_records": sum(r.get('records_count', 0) for r in results.values()),
-            "metrics": metrics.dict() if metrics else {},
+            "metrics": metrics.model_dump() if metrics else {},
         }
 
         metadata_path = base_dir / "ingestion_metadata.json"

--- a/tests/test_hubeau_ingestion_service.py
+++ b/tests/test_hubeau_ingestion_service.py
@@ -1,5 +1,6 @@
 """Tests ciblés pour le service d'ingestion Bronze Hub'Eau."""
 
+import asyncio
 import json
 from pathlib import Path
 
@@ -7,7 +8,8 @@ import boto3
 import pytest
 from botocore.stub import ANY, Stubber
 
-from hubeau_pipeline.assets.bronze.hubeau_client import HubeauIngestionService
+from hubeau_pipeline.assets.bronze.hubeau_client import HubeauIngestionService, IngestionMetrics
+from hubeau_pipeline.assets.bronze.hubeau_configs import get_hydrobiology_config
 
 
 def _build_stubbed_s3_client():
@@ -119,3 +121,70 @@ def test_local_fallback_is_used(tmp_path, monkeypatch):
 
     metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
     assert metadata["total_records"] == 1
+
+
+def test_ingestion_persists_metadata_for_empty_partitions(tmp_path, monkeypatch):
+    """Même sans données, une partition traitée doit laisser une trace."""
+
+    monkeypatch.setenv("MINIO_USER", "test")
+    monkeypatch.setenv("MINIO_PASS", "test")
+    monkeypatch.setenv("HUBEAU_LOCAL_CACHE", str(tmp_path))
+
+    def _raise_minio(self):
+        raise RuntimeError("minio indisponible")
+
+    monkeypatch.setattr(
+        HubeauIngestionService,
+        "_init_minio_client",
+        _raise_minio,
+        raising=False,
+    )
+
+    class DummyClient:
+        """Client Hub'Eau minimal qui renvoie des listes vides."""
+
+        def __init__(self, config):
+            self.metrics = IngestionMetrics()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get_stations(self, endpoint_name):
+            return []
+
+        async def get_observations(
+            self,
+            endpoint_name,
+            entity_codes,
+            date_partition,
+            api_name=None,
+            realtime=False,
+            partition_key=None,
+        ):
+            return []
+
+    monkeypatch.setattr(
+        "hubeau_pipeline.assets.bronze.hubeau_client.HubeauClient",
+        DummyClient,
+    )
+
+    async def _run_test():
+        service = HubeauIngestionService()
+        config = get_hydrobiology_config()
+
+        result = await service.ingest_api_data(config, "2024-01-01")
+
+        expected_dir = Path(tmp_path, config.name, "2024-01-01")
+        metadata_file = expected_dir / "ingestion_metadata.json"
+
+        assert metadata_file.exists()
+
+        metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+        assert metadata["total_records"] == 0
+        assert result["status"] == "no_data"
+        assert result["errors"] == []
+
+    asyncio.run(_run_test())


### PR DESCRIPTION
## Summary
- raise a dedicated `HubeauPageFetchError` and stop returning partial data when Hub'Eau pages fail
- ensure `HubeauIngestionService` always persists partition metadata, surfaces partial failures, and serialises metrics with `model_dump`
- replace the manual hydrobiology regression script with pytest-backed tests and add coverage for empty partitions
- switch the hydrobiology regression fixtures to timezone-aware timestamps to avoid `utcnow` deprecation warnings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd2d7e80e88327a325c17c930ce916