### PR TITLE
Fix temperature ingestion by chunking yearly data monthly

### DIFF
--- a/src/hubeau_pipeline/assets/bronze/hubeau_client.py
+++ b/src/hubeau_pipeline/assets/bronze/hubeau_client.py
@@ -362,9 +362,92 @@ class HubeauClient:
 
         return cursor_values[0]
     
+    async def get_temperature_observations_yearly(
+        self,
+        station_code: str,
+        date_partition: str,
+    ) -> List[Dict[str, Any]]:
+        """Récupère les observations de température mois par mois pour éviter la limite de 20k enregistrements.
+
+        L'API Hub'Eau limite la profondeur d'accès (page * size) à 20 000 enregistrements. Certaines stations
+        de température disposent d'une mesure toutes les 5 minutes, ce qui dépasse cette limite sur une année
+        complète (≈100k enregistrements). Pour garantir une ingestion exhaustive, on découpe donc l'année en
+        12 fenêtres mensuelles et on interroge l'endpoint `chronique` pour chacune d'elles.
+        """
+
+        endpoint_name = "chronique"
+        if endpoint_name not in self.config.endpoints:
+            self.logger.error("❌ Endpoint 'chronique' introuvable pour l'API température")
+            return []
+
+        endpoint_config = self.config.endpoints[endpoint_name]
+        temporal_params = endpoint_config.temporal_params or {}
+        start_key = temporal_params.get("start")
+        end_key = temporal_params.get("end")
+
+        if not start_key or not end_key:
+            self.logger.error("❌ Configuration temporelle manquante pour l'endpoint chronique (température)")
+            return []
+
+        try:
+            partition_dt = datetime.strptime(date_partition, "%Y-%m-%d")
+        except ValueError:
+            # Support des partitions ISO complètes (ex: "2024")
+            partition_dt = datetime(int(date_partition[:4]), 1, 1)
+
+        year = partition_dt.year
+        all_data: List[Dict[str, Any]] = []
+
+        self.logger.info(
+            "🌡️ Température: récupération mensuelle pour la station %s (année %s)",
+            station_code,
+            year,
+        )
+
+        base_params = {"format": "json", "size": endpoint_config.page_size, "code_station": station_code}
+
+        for month in range(1, 13):
+            start_dt = datetime(year, month, 1)
+            if month == 12:
+                end_dt = datetime(year + 1, 1, 1)
+            else:
+                end_dt = datetime(year, month + 1, 1)
+
+            month_params = base_params.copy()
+            month_params[start_key] = start_dt.strftime("%Y-%m-%d")
+            month_params[end_key] = end_dt.strftime("%Y-%m-%d")
+
+            self.logger.debug(
+                "🌡️ Température: station %s, mois %02d → fenêtre [%s → %s[",
+                station_code,
+                month,
+                month_params[start_key],
+                month_params[end_key],
+            )
+
+            month_data = await self._fetch_all_pages(endpoint_config, month_params)
+            all_data.extend(month_data)
+
+            if month_data:
+                self.logger.info(
+                    "✅ Température: %s observations pour %s-%02d",
+                    len(month_data),
+                    year,
+                    month,
+                )
+
+        self.logger.info(
+            "🎯 Température: %s observations totales récupérées pour %s (%s)",
+            len(all_data),
+            station_code,
+            year,
+        )
+
+        return all_data
+
     async def get_observations(
-        self, 
-        endpoint_name: str, 
+        self,
+        endpoint_name: str,
         entity_codes: List[str],
         date_partition: str,
         api_name: str = None,
@@ -1222,24 +1305,38 @@ class HubeauIngestionService:
                     if config.name == "temperature" and station_codes:
                         self.logger.info(f"🌡️ Température: Traitement de {len(station_codes)} stations une par une")
                         all_observations = []
-                        
-                        # Traiter les stations par chunks de 1 pour respecter la limite 20k
+
                         for i, station_code in enumerate(station_codes):
                             try:
                                 self.logger.debug(f"🌡️ Station {i+1}/{len(station_codes)}: {station_code}")
-                                station_observations = await client.get_observations(
-                                    endpoint_name, 
-                                    [station_code],  # Une seule station à la fois
-                                    date_partition,
-                                    config.name,
-                                    partition_key=partition_key
-                                )
+
+                                original_key = partition_key if partition_key else date_partition
+                                is_yearly_partition = len(original_key) == 4
+
+                                if is_yearly_partition:
+                                    station_observations = await client.get_temperature_observations_yearly(
+                                        station_code,
+                                        date_partition,
+                                    )
+                                else:
+                                    station_observations = await client.get_observations(
+                                        endpoint_name,
+                                        [station_code],
+                                        date_partition,
+                                        config.name,
+                                        partition_key=partition_key
+                                    )
+
                                 all_observations.extend(station_observations)
-                                self.logger.debug(f"🌡️ Station {station_code}: {len(station_observations)} observations")
+                                self.logger.debug(
+                                    "🌡️ Station %s: %s observations cumulées",
+                                    station_code,
+                                    len(station_observations),
+                                )
                             except Exception as e:
                                 self.logger.warning(f"⚠️ Erreur station {station_code}: {e}")
                                 continue
-                        
+
                         results[endpoint_name] = {
                             'records_count': len(all_observations),
                             'type': 'observations',

--- a/tests/test_hubeau_client.py
+++ b/tests/test_hubeau_client.py
@@ -101,3 +101,56 @@ def test_fetch_all_pages_cursor_missing_token(monkeypatch):
     data = asyncio.run(_run())
 
     assert data == [{"id": 1}]
+
+
+def test_temperature_observations_split_by_month(monkeypatch):
+    """L'ingestion température annuelle doit découper l'année en 12 fenêtres mensuelles."""
+
+    async def _run():
+        config = HubeauApiConfig(
+            name="temperature",
+            base_url="https://example.com",
+            endpoints={
+                "chronique": HubeauEndpointConfig(
+                    path="chronique",
+                    temporal_params={"start": "date_debut_mesure", "end": "date_fin_mesure"},
+                    page_size=1000,
+                    max_pages=20,
+                )
+            },
+        )
+
+        async with HubeauClient(config) as client:
+            captured_windows = []
+
+            async def _fake_fetch_all_pages(endpoint_config, params, bubble_exceptions=False):
+                captured_windows.append(
+                    (
+                        params["date_debut_mesure"],
+                        params["date_fin_mesure"],
+                    )
+                )
+                # Simule une observation par fenêtre
+                return [
+                    {
+                        "code_station": params["code_station"],
+                        "date_mesure_temp": params["date_debut_mesure"],
+                        "resultat": 12.3,
+                    }
+                ]
+
+            monkeypatch.setattr(client, "_fetch_all_pages", _fake_fetch_all_pages)
+
+            data = await client.get_temperature_observations_yearly("ST001", "2023-01-01")
+
+        return data, captured_windows
+
+    data, captured = asyncio.run(_run())
+
+    assert len(captured) == 12  # 12 mois
+    # Première fenêtre: janvier 2023
+    assert captured[0] == ("2023-01-01", "2023-02-01")
+    # Dernière fenêtre: décembre 2023 → début 2024
+    assert captured[-1] == ("2023-12-01", "2024-01-01")
+    # Une observation synthétique par mois → 12 au total
+    assert len(data) == 12

--- a/tests/test_hubeau_ingestion_service.py
+++ b/tests/test_hubeau_ingestion_service.py
@@ -9,7 +9,10 @@ import pytest
 from botocore.stub import ANY, Stubber
 
 from hubeau_pipeline.assets.bronze.hubeau_client import HubeauIngestionService, IngestionMetrics
-from hubeau_pipeline.assets.bronze.hubeau_configs import get_hydrobiology_config
+from hubeau_pipeline.assets.bronze.hubeau_configs import (
+    get_hydrobiology_config,
+    get_temperature_config,
+)
 
 
 def _build_stubbed_s3_client():
@@ -188,3 +191,68 @@ def test_ingestion_persists_metadata_for_empty_partitions(tmp_path, monkeypatch)
         assert result["errors"] == []
 
     asyncio.run(_run_test())
+
+
+def test_temperature_ingestion_uses_monthly_strategy(monkeypatch):
+    """L'ingestion température annuelle doit utiliser la stratégie mensuelle dédiée."""
+
+    class DummyTemperatureClient:
+        def __init__(self, config):
+            self.metrics = IngestionMetrics()
+            self.config = config
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get_stations(self, endpoint_name):
+            return [{"code_station": "ST001"}]
+
+        async def get_temperature_observations_yearly(self, station_code, date_partition):
+            assert station_code == "ST001"
+            assert date_partition == "2023-01-01"
+            return [
+                {
+                    "code_station": station_code,
+                    "date_mesure_temp": "2023-01-01",
+                    "resultat": 15.5,
+                }
+            ]
+
+        async def get_observations(
+            self,
+            endpoint_name,
+            entity_codes,
+            date_partition,
+            api_name=None,
+            realtime=False,
+            partition_key=None,
+        ):
+            raise AssertionError("La stratégie mensuelle doit éviter get_observations pour les partitions annuelles")
+
+    monkeypatch.setattr(
+        "hubeau_pipeline.assets.bronze.hubeau_client.HubeauClient",
+        DummyTemperatureClient,
+    )
+
+    def _noop_save(self, *args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        HubeauIngestionService,
+        "_save_to_minio",
+        _noop_save,
+    )
+
+    async def _run():
+        service = HubeauIngestionService()
+        config = get_temperature_config()
+        result = await service.ingest_api_data(config, "2023-01-01", partition_key="2023")
+
+        observations = result["results_by_endpoint"]["chronique"]
+        assert observations["records_count"] == 1
+        assert observations["data"][0]["resultat"] == 15.5
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add a dedicated helper that retrieves temperature chronicle data month by month to stay under the 20k record depth limit documented by Hub'Eau
- update the bronze ingestion flow to rely on the monthly helper for yearly temperature partitions and keep the per-station fallback for other partitions
- cover the new behaviour with unit tests ensuring the helper splits the requests correctly and that the ingestion service uses it

## Testing
- PYTHONPATH=src pytest tests -k temperature


------
https://chatgpt.com/codex/tasks/task_e_68de6f074c188327b5b822dbb01c80c3