### PR TITLE
Align dlt assets and pipeline with Dagster configuration

### DIFF
--- a/pipelines/dlt/http_client.py
+++ b/pipelines/dlt/http_client.py
@@ -62,40 +62,84 @@ class HttpClient:
         self.default_headers = cfg.get("headers", {})
         self.backoff_initial = cfg.get("backoff_initial", 1.0)
         self.backoff_max = cfg.get("backoff_max", 120.0)
+        self.max_attempts = max(int(cfg.get("max_attempts", 5)), 1)
+
+    # --- context management --------------------------------------------
+    def close(self) -> None:
+        if hasattr(self.session, "close"):
+            self.session.close()
+
+    def __enter__(self) -> "HttpClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
 
     # --- public API -----------------------------------------------------
-    def get(self, path: str, params: Dict[str, Any]) -> Dict[str, Any]:
-        """Perform a GET request with retry/backoff.
-
-        The method retries on 5xx status codes and HTTP 429 (rate limit).
-        For other codes, :meth:`httpx.Response.raise_for_status` is called.
-        """
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json_body: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """Perform an HTTP request with retry/backoff support."""
 
         url = f"{self.base_url}/{path.lstrip('/')}"
+        method = method.upper()
         backoff = self.backoff_initial
-        while True:
+        attempts = 0
+        header_payload = dict(self.default_headers)
+        if headers:
+            header_payload.update(headers)
+
+        while attempts < self.max_attempts:
+            attempts += 1
             self.bucket.consume(1.0)
             try:
-                response = self.session.get(url, params=params, headers=self.default_headers)
-            except httpx.HTTPError as exc:  # network errors
+                response = self.session.request(
+                    method,
+                    url,
+                    params=params or None,
+                    json=json_body,
+                    data=data,
+                    headers=header_payload or None,
+                )
+            except httpx.HTTPError:
+                if attempts >= self.max_attempts:
+                    raise
                 time.sleep(min(backoff, self.backoff_max))
                 backoff = min(self.backoff_max, backoff * 1.7)
                 continue
 
             if response.status_code == 429:
                 self._handle_429()
+                if attempts >= self.max_attempts:
+                    response.raise_for_status()
                 time.sleep(min(backoff, self.backoff_max))
                 backoff = min(self.backoff_max, backoff * 1.7)
                 continue
 
             if response.status_code >= 500:
+                if attempts >= self.max_attempts:
+                    response.raise_for_status()
                 time.sleep(min(backoff, self.backoff_max))
                 backoff = min(self.backoff_max, backoff * 1.7)
                 continue
 
             response.raise_for_status()
             self._maybe_increase_rps()
-            return response.json()
+            return self._decode_response(response)
+
+        raise RuntimeError("HTTP request failed after exhausting retry attempts")
+
+    def get(self, path: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Backward compatible helper for GET requests."""
+
+        return self.request("GET", path, params=params)
 
     def extract_records(self, payload: Dict[str, Any], records_path: Optional[str]) -> Iterable[Dict[str, Any]]:
         """Extract records from the JSON payload using JSONPath.
@@ -113,10 +157,16 @@ class HttpClient:
         matches = parse(records_path).find(payload)
         if not matches:
             return []
-        records = matches[0].value
-        if isinstance(records, list):
-            return records
-        return [records]
+        aggregated = []
+        for match in matches:
+            value = match.value
+            if value is None:
+                continue
+            if isinstance(value, list):
+                aggregated.extend(value)
+            else:
+                aggregated.append(value)
+        return aggregated
 
     # --- helpers --------------------------------------------------------
     def _handle_429(self) -> None:
@@ -131,6 +181,12 @@ class HttpClient:
         now = time.monotonic()
         if now - self.last_429_ts > self.rate_limit_cfg.rps_increase_cooldown_s:
             self.bucket.fill_rate = min(self.bucket.fill_rate * 1.05, 5.0)
+
+    def _decode_response(self, response: httpx.Response) -> Dict[str, Any]:
+        try:
+            return response.json()
+        except ValueError as exc:  # pragma: no cover - defensive branch
+            raise ValueError("Expected JSON response from API") from exc
 
 
 __all__ = ["HttpClient", "TokenBucket"]

--- a/pipelines/dlt/hubeau_generic.py
+++ b/pipelines/dlt/hubeau_generic.py
@@ -1,6 +1,7 @@
 """Generic dlt pipeline that ingests HubEau endpoints defined via YAML."""
 from __future__ import annotations
 
+import os
 import re
 from collections import deque
 from pathlib import Path
@@ -85,9 +86,14 @@ def _should_stop_pagination(
 
 
 @dlt.source(name="hubeau")
-def hubeau_source(cfg: Dict[str, Any]):
+def hubeau_source(cfg: Dict[str, Any], *, client: HttpClient | None = None):
+    """Return the dlt resource streaming Hub'Eau data."""
+
     validated_cfg = validate_config(cfg)
-    client = HttpClient(cfg)
+    resolved_cfg = validated_cfg.model_dump(mode="python")
+
+    http_client = client or HttpClient(resolved_cfg)
+    owns_client = client is None
 
     @dlt.resource(
         name=validated_cfg.name,
@@ -95,50 +101,58 @@ def hubeau_source(cfg: Dict[str, Any]):
         primary_key=validated_cfg.primary_keys,
     )
     def stream() -> Iterator[Dict[str, Any]]:
-        pagination = cfg.get("pagination") or {}
-        slices: Deque[Slice] = deque(build_slices(cfg))
+        pagination = resolved_cfg.get("pagination") or {}
+        method = resolved_cfg.get("method", "GET").upper()
+        slices: Deque[Slice] = deque(build_slices(resolved_cfg))
 
-        while slices:
-            slice_obj = slices.popleft()
-            page = 1
-            buffered_batches: List[List[Dict[str, Any]]] = []
-            total_records = 0
-            truncated = False
+        try:
+            while slices:
+                slice_obj = slices.popleft()
+                page = 1
+                buffered_batches: List[List[Dict[str, Any]]] = []
+                total_records = 0
+                truncated = False
 
-            while True:
-                params = _build_params(cfg, slice_obj, page if pagination else None)
-                payload = client.get(cfg["path"], params=params)
-                batch = list(client.extract_records(payload, cfg.get("records_path")))
-                buffered_batches.append(batch)
-                total_records += len(batch)
+                while True:
+                    params = _build_params(resolved_cfg, slice_obj, page if pagination else None)
+                    request_kwargs: Dict[str, Any] = {"params": params}
+                    if method in {"POST", "PUT", "PATCH"}:
+                        request_kwargs["json_body"] = params
+                    payload = http_client.request(method, resolved_cfg["path"], **request_kwargs)
+                    batch = list(http_client.extract_records(payload, resolved_cfg.get("records_path")))
+                    buffered_batches.append(batch)
+                    total_records += len(batch)
 
-                if needs_truncation(total_records, cfg):
-                    truncated = True
-                    break
+                    if needs_truncation(total_records, resolved_cfg):
+                        truncated = True
+                        break
 
-                if _should_stop_pagination(payload, batch, pagination):
-                    break
+                    if _should_stop_pagination(payload, batch, pagination):
+                        break
 
-                page += 1
+                    page += 1
 
-            if truncated:
-                fallback_slices = generate_fallback_slices(slice_obj, cfg, slice_obj.level)
-                if not fallback_slices:
-                    for batch in buffered_batches:
-                        for record in batch:
-                            record["_slice_id"] = slice_obj.slice_id
-                            record["_scope"] = slice_obj.scope
-                            yield record
+                if truncated:
+                    fallback_slices = generate_fallback_slices(slice_obj, resolved_cfg, slice_obj.level)
+                    if not fallback_slices:
+                        for batch in buffered_batches:
+                            for record in batch:
+                                record["_slice_id"] = slice_obj.slice_id
+                                record["_scope"] = slice_obj.scope
+                                yield record
+                        continue
+                    for new_slice in reversed(fallback_slices):
+                        slices.appendleft(new_slice)
                     continue
-                for new_slice in reversed(fallback_slices):
-                    slices.appendleft(new_slice)
-                continue
 
-            for batch in buffered_batches:
-                for record in batch:
-                    record["_slice_id"] = slice_obj.slice_id
-                    record["_scope"] = slice_obj.scope
-                    yield record
+                for batch in buffered_batches:
+                    for record in batch:
+                        record["_slice_id"] = slice_obj.slice_id
+                        record["_scope"] = slice_obj.scope
+                        yield record
+        finally:
+            if owns_client:
+                http_client.close()
 
     return stream
 
@@ -149,51 +163,85 @@ def run_pipeline(
     bucket_url: Optional[str] = None,
     credentials: Optional[Dict[str, Any]] = None,
     dataset_name: Optional[str] = None,
-    file_format: str = "parquet",
+    file_format: str = "json",
     layout: Optional[str] = None,
     state_fs_options: Optional[Dict[str, Any]] = None,
 ) -> dlt.LoadInfo:
-    destination_kwargs: Dict[str, Any] = {
-        "bucket_url": bucket_url,
-        "credentials": credentials,
-        "file_format": file_format,
-    }
-    if layout:
-        destination_kwargs["layout"] = layout
+    validated_cfg = validate_config(cfg)
+    resolved_cfg = validated_cfg.model_dump(mode="python")
+
+    destination_kwargs: Dict[str, Any] = {}
+    resolved_bucket = bucket_url or resolved_cfg.get("bucket_url")
+    if not resolved_bucket:
+        env_path = os.getenv("DESTINATION__FILESYSTEM__PATH")
+        if env_path:
+            resolved_bucket = Path(env_path).expanduser().resolve().as_uri()
+    if resolved_bucket:
+        destination_kwargs["bucket_url"] = resolved_bucket
+    if credentials:
+        destination_kwargs["credentials"] = credentials
+
+    explicit_file_format = resolved_cfg.get("file_format") or file_format
+    if explicit_file_format:
+        destination_kwargs["file_format"] = explicit_file_format
+    if layout or resolved_cfg.get("layout"):
+        destination_kwargs["layout"] = resolved_cfg.get("layout") or layout
+
     # Remove empty values to let dlt rely on defaults when not provided
     destination_kwargs = {k: v for k, v in destination_kwargs.items() if v}
 
-    target_dataset = dataset_name or cfg.get("dataset_name") or cfg["source"]
-    destination_kwargs.setdefault(
-        "layout",
-        "{schema_name}/{table_name}/format=parquet/run_date={curr_date}/part-{file_id}",
-    )
+    target_dataset = dataset_name or resolved_cfg.get("dataset_name") or "bronze"
+    destination_kwargs.setdefault("layout", "{table_name}/{curr_date}/data.json")
 
-    destination = filesystem(**destination_kwargs)
-    
-    # Create a dlt pipeline
-    pipeline_name = f"hubeau_{cfg['name']}"
+    destination = filesystem(**destination_kwargs) if destination_kwargs else filesystem()
+
+    pipeline_name = f"hubeau_{resolved_cfg['name']}"
     pipeline = dlt.pipeline(
         pipeline_name=pipeline_name,
         destination=destination,
         dataset_name=target_dataset,
     )
-    
-    # Run the pipeline
-    load_info = pipeline.run(hubeau_source(cfg))
-    
-    # Save state
+
+    with HttpClient(resolved_cfg) as http_client:
+        load_info = pipeline.run(hubeau_source(resolved_cfg, client=http_client))
+
     state = pipeline.state
     if state:
         save_state_copy(
-            cfg["source"],
-            cfg["name"],
+            resolved_cfg["source"],
+            resolved_cfg["name"],
             state,
-            fs_url=cfg.get("state_store"),
-            fs_options=state_fs_options,
+            fs_url=resolved_cfg.get("state_store"),
+            fs_options=_normalise_state_options(state_fs_options),
         )
-    
+
     return load_info
+
+
+def _normalise_state_options(options: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Convert user-provided state options to fsspec compatible values."""
+
+    if not options:
+        return None
+
+    normalised: Dict[str, Any] = {}
+    client_kwargs: Dict[str, Any] = {}
+    for key, value in options.items():
+        if value in (None, ""):
+            continue
+        if key == "aws_access_key_id":
+            normalised["key"] = str(value)
+        elif key == "aws_secret_access_key":
+            normalised["secret"] = str(value)
+        elif key in {"endpoint_url", "region_name"}:
+            client_kwargs[key] = value
+        else:
+            normalised[key] = value
+    if client_kwargs:
+        merged_kwargs = dict(normalised.get("client_kwargs", {}))
+        merged_kwargs.update(client_kwargs)
+        normalised["client_kwargs"] = merged_kwargs
+    return normalised or None
 
 
 def run_from_file(config_path: str | Path) -> dlt.LoadInfo:

--- a/pipelines/dlt/slicing.py
+++ b/pipelines/dlt/slicing.py
@@ -73,7 +73,7 @@ def _resolve_reference_values(cfg: Dict[str, Any], key: str) -> List[str]:
         if isinstance(values, list):
             return values
 
-    pre_scan_cfg = cfg.get("pre_scan", {}).get(key.rstrip("s") + "s", {})
+    pre_scan_cfg = (cfg.get("pre_scan") or {}).get(key.rstrip("s") + "s", {})
     if pre_scan_cfg.get("enabled") and "values" in pre_scan_cfg:
         values = pre_scan_cfg["values"]
         if isinstance(values, list):
@@ -253,7 +253,7 @@ def _split_slice_station_month(slice_obj: Slice, cfg: Dict[str, Any], next_level
 def generate_fallback_slices(slice_obj: Slice, cfg: Dict[str, Any], current_level: int) -> List[Slice]:
     """Generate fallback slices following the configured split chain."""
 
-    chain = cfg.get("fallbacks", {}).get("split_chain", []) or []
+    chain = (cfg.get("fallbacks") or {}).get("split_chain", []) or []
     if current_level >= len(chain):
         return []
     strategy = chain[current_level]
@@ -265,7 +265,8 @@ def generate_fallback_slices(slice_obj: Slice, cfg: Dict[str, Any], current_leve
 
 
 def needs_truncation(count: int, cfg: Dict[str, Any]) -> bool:
-    threshold = cfg.get("fallbacks", {}).get("truncation_threshold", TRUNCATION_DEFAULT)
+    fallbacks_cfg = cfg.get("fallbacks") or {}
+    threshold = fallbacks_cfg.get("truncation_threshold", TRUNCATION_DEFAULT)
     return count >= threshold
 
 

--- a/pipelines/dlt/state.py
+++ b/pipelines/dlt/state.py
@@ -4,10 +4,19 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import date, datetime
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Optional
 
-import fsspec
+from fsspec.core import url_to_fs
+
+try:  # pragma: no cover - optional dependency
+    import pendulum
+
+    _PENDULUM_TYPES: Iterable[type] = (pendulum.DateTime,)
+except ImportError:  # pragma: no cover - optional dependency
+    pendulum = None
+    _PENDULUM_TYPES = ()
 
 
 def _local_state_path(source: str, stream: str) -> Path:
@@ -24,14 +33,31 @@ def save_state_copy(
 ) -> Path:
     path = _local_state_path(source, stream)
     path.parent.mkdir(parents=True, exist_ok=True)
+    serializable_state = _make_json_serializable(state)
     with path.open("w", encoding="utf-8") as fp:
-        json.dump(state, fp, ensure_ascii=False, indent=2)
+        json.dump(serializable_state, fp, ensure_ascii=False, indent=2)
 
     if fs_url:
         options = dict(fs_options or {})
         options.setdefault("skip_instance_cache", True)
-        fs = fsspec.filesystem("s3", **options)
-        remote_path = os.path.join(fs_url.rstrip("/"), f"{source}/{stream}.state.json")
-        with fs.open(remote_path, "w") as remote:
-            json.dump(state, remote, ensure_ascii=False)
+        fs, base_path = url_to_fs(fs_url, **options)
+        remote_path = f"{base_path.rstrip('/')}/{source}/{stream}.state.json"
+        with fs.open(remote_path, "w", encoding="utf-8") as remote:
+            json.dump(serializable_state, remote, ensure_ascii=False)
     return path
+
+
+def _make_json_serializable(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if _PENDULUM_TYPES and isinstance(value, tuple(_PENDULUM_TYPES)):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {k: _make_json_serializable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_make_json_serializable(v) for v in value]
+    if hasattr(value, "to_dict"):
+        return _make_json_serializable(value.to_dict())
+    return repr(value)

--- a/src/hubeau_pipeline/assets/__init__.py
+++ b/src/hubeau_pipeline/assets/__init__.py
@@ -44,6 +44,6 @@ all_assets = production_assets  # Seulement Bronze réels pour tests
 
 __all__ = [
     "all_assets",
-    "production_assets"
+    "production_assets",
     # "demo_assets"  # Temporairement désactivé
 ]

--- a/src/hubeau_pipeline/assets/dlt_assets.py
+++ b/src/hubeau_pipeline/assets/dlt_assets.py
@@ -1,4 +1,4 @@
-"""Dagster assets orchestrating dlt based pipelines."""
+"""Dagster assets orchestrating Hub'Eau dlt pipelines."""
 from __future__ import annotations
 
 import os
@@ -6,32 +6,64 @@ from pathlib import Path
 from typing import Any, Dict
 
 import yaml
-from dagster import AssetExecutionContext, MetadataValue, asset
+from dagster import AssetExecutionContext, DailyPartitionsDefinition, StaticPartitionsDefinition, asset
+from dlt.common.typing import TSecretValue
 
 from pipelines.dlt.hubeau_generic import run_pipeline
 
+# Partitions pour les données historiques (annuelles depuis 2020)
+YEARLY_PARTITIONS = StaticPartitionsDefinition([str(year) for year in range(2020, 2026)])
 
-def _build_credentials() -> Dict[str, str]:
-    endpoint = os.getenv("MINIO_ENDPOINT", "http://minio:9000")
-    region = os.getenv("MINIO_REGION", "us-east-1")
-    access_key = os.getenv("MINIO_USER")
-    secret_key = os.getenv("MINIO_PASS")
-    creds = {
-        "aws_access_key_id": access_key,
-        "aws_secret_access_key": secret_key,
-        "endpoint_url": endpoint,
-        "region_name": region,
+# Partitions pour les données temps réel (30 derniers jours)
+DAILY_PARTITIONS = DailyPartitionsDefinition(start_date="2022-01-01")
+
+
+def _resolve_config_path(config_path: str) -> Path:
+    """Return an absolute path for the provided configuration file."""
+
+    candidate = Path(config_path)
+    if candidate.is_absolute() and candidate.exists():
+        return candidate
+
+    # Dagster images mount the repository in /app, fall back to the repo root otherwise
+    repo_root = Path("/app")
+    resolved = repo_root / config_path.lstrip("/")
+    if resolved.exists():
+        return resolved
+
+    # Default to the project root relative path
+    return Path.cwd() / config_path
+
+
+def _build_credentials() -> Dict[str, TSecretValue]:
+    """Build MinIO/S3 credentials expected by dlt destinations."""
+
+    minio_user = os.getenv("MINIO_USER", "admin")
+    minio_pass = os.getenv("MINIO_PASS", "BrgmMinio2024!")
+    minio_endpoint = os.getenv("MINIO_ENDPOINT", "http://minio:9000")
+    minio_region = os.getenv("MINIO_REGION", "us-east-1")
+    return {
+        "aws_access_key_id": TSecretValue(minio_user),
+        "aws_secret_access_key": TSecretValue(minio_pass),
+        "endpoint_url": minio_endpoint,
+        "region_name": minio_region,
     }
-    return {k: v for k, v in creds.items() if v}
 
 
-def _build_state_fs_options(credentials: Dict[str, str]) -> Dict[str, Any]:
+def _build_state_fs_options(credentials: Dict[str, TSecretValue]) -> Dict[str, Any]:
+    """Return fsspec-compatible options to persist dlt state remotely."""
+
+    key = credentials.get("aws_access_key_id")
+    secret = credentials.get("aws_secret_access_key")
     endpoint = credentials.get("endpoint_url")
     region = credentials.get("region_name")
-    fs_options: Dict[str, Any] = {
-        "key": credentials.get("aws_access_key_id"),
-        "secret": credentials.get("aws_secret_access_key"),
-    }
+
+    fs_options: Dict[str, Any] = {}
+    if key:
+        fs_options["key"] = str(key)
+    if secret:
+        fs_options["secret"] = str(secret)
+
     client_kwargs: Dict[str, Any] = {}
     if endpoint:
         client_kwargs["endpoint_url"] = endpoint
@@ -39,150 +71,156 @@ def _build_state_fs_options(credentials: Dict[str, str]) -> Dict[str, Any]:
         client_kwargs["region_name"] = region
     if client_kwargs:
         fs_options["client_kwargs"] = client_kwargs
-    return {k: v for k, v in fs_options.items() if v}
+
+    return fs_options
 
 
-@asset(io_manager_key="minio_io_manager", compute_kind="python", required_resource_keys={"s3"})
+# ====================================
+# Generic dlt Ingestion Asset
+# ====================================
+
+
 def ingest_dlt(context: AssetExecutionContext, config_path: str) -> Dict[str, Any]:
-    cfg = yaml.safe_load(Path(config_path).read_text())
-    context.log.info("Launching dlt pipeline for %s", cfg["name"])
+    """Execute a dlt pipeline described by a YAML configuration file."""
 
-    minio_bucket = getattr(context.resources, "s3", {}).get("bucket")
-    bucket_url = f"s3://{minio_bucket}" if minio_bucket else None
+    config_file = _resolve_config_path(config_path)
+    context.log.info("🚀 Starting dlt ingestion for config: %s", config_file)
+
+    with config_file.open("r", encoding="utf-8") as handle:
+        cfg = yaml.safe_load(handle)
+
+    partition_key = context.partition_key if context.has_partition_key else None
+    if partition_key and cfg.get("slicer", {}).get("mode") == "datetime":
+        from datetime import datetime
+
+        context.log.info("📅 Partition: %s", partition_key)
+        try:
+            if len(partition_key) == 4 and partition_key.isdigit():
+                year = int(partition_key)
+                cfg["slicer"]["start_date"] = f"{year}-01-01"
+                cfg["slicer"]["end_date"] = f"{year}-12-31"
+                context.log.info("🗓️ Ingestion pour l'année %s", year)
+            else:
+                datetime.strptime(partition_key, "%Y-%m-%d")
+                cfg["slicer"]["start_date"] = partition_key
+                cfg["slicer"]["end_date"] = partition_key
+                context.log.info("🗓️ Ingestion pour le jour %s", partition_key)
+        except ValueError:
+            context.log.warning("⚠️ Could not parse partition key: %s", partition_key)
+
+    context.log.info("Loaded dlt config: %s", cfg["name"])
+
     credentials = _build_credentials()
-    fs_options = _build_state_fs_options(credentials)
-
-    if not credentials.get("aws_access_key_id") or not credentials.get("aws_secret_access_key"):
-        context.log.warning(
-            "Missing explicit MinIO credentials in environment; relying on default client configuration"
-        )
-
-    cfg.setdefault("state_store", f"{bucket_url.rstrip('/')}/_state" if bucket_url else None)
+    state_fs_options = _build_state_fs_options(credentials)
+    bucket_url = "s3://bronze"
 
     load_info = run_pipeline(
         cfg,
         bucket_url=bucket_url,
         credentials=credentials,
-        dataset_name=cfg.get("dataset_name"),
-        file_format=cfg.get("file_format", "parquet"),
-        layout=cfg.get("layout"),
-        state_fs_options=fs_options,
+        dataset_name=cfg.get("dataset_name", "bronze"),
+        file_format=cfg.get("file_format", "json"),
+        layout=cfg.get("layout", "{table_name}/{curr_date}/data.json"),
+        state_fs_options=state_fs_options,
     )
+
+    context.log.info("✅ dlt pipeline for %s finished.", cfg["name"])
+
     row_count = 0
-    if hasattr(load_info, "metrics"):
-        row_count = load_info.metrics.row_counts.get(cfg["name"], 0)
-    context.add_output_metadata(
-        {
-            "stream": MetadataValue.text(cfg["name"]),
-            "rows": MetadataValue.int(row_count),
-            "destination": MetadataValue.text("bronze"),
-        }
-    )
+    if hasattr(load_info, "load_packages") and load_info.load_packages:
+        for package in load_info.load_packages:
+            for job in getattr(package, "jobs", []):
+                if getattr(job, "job_file_type", None) == "data":
+                    row_count += getattr(job, "records_count", 0)
+
     return {"stream": cfg["name"], "rows": row_count}
 
 
 # ====================================
-# ASSETS HYDROBIOLOGIE
+# Hub'Eau Specific dlt Assets
 # ====================================
 
-@asset(required_resource_keys={"s3"})
+
+@asset(group_name="hubeau_hydrobiology", partitions_def=YEARLY_PARTITIONS)
 def hydrobio_taxons(context: AssetExecutionContext) -> Dict[str, Any]:
-    """🐟 Hydrobiologie - Taxons biologiques"""
+    """Ingests hydrobiology taxons data using dlt."""
+
     return ingest_dlt(context, "configs/hubeau/hydrobio_taxons.yml")
 
 
-@asset(required_resource_keys={"s3"})
+@asset(group_name="hubeau_hydrobiology", partitions_def=YEARLY_PARTITIONS)
 def hydrobio_indices(context: AssetExecutionContext) -> Dict[str, Any]:
-    """🐟 Hydrobiologie - Indices biologiques (IBGN, I2M2, etc.)"""
+    """Ingests hydrobiology indices data using dlt."""
+
     return ingest_dlt(context, "configs/hubeau/hydrobio_indices.yml")
 
 
-# ====================================
-# ASSETS HYDROMÉTRIE
-# ====================================
-
-@asset(required_resource_keys={"s3"})
+@asset(group_name="hubeau_hydrometry")
 def hydrometry_observations(context: AssetExecutionContext) -> Dict[str, Any]:
-    """🌊 Hydrométrie - Observations temps réel (30 derniers jours)"""
+    """Ingests hydrometry observations data using dlt (30 derniers jours)."""
+
     return ingest_dlt(context, "configs/hubeau/hydrometry_observations.yml")
 
 
-# ====================================
-# ASSETS PIÉZOMÉTRIE
-# ====================================
-
-@asset(required_resource_keys={"s3"})
+@asset(group_name="hubeau_piezometry", partitions_def=DAILY_PARTITIONS)
 def piezometry_chroniques(context: AssetExecutionContext) -> Dict[str, Any]:
-    """🕳️ Piézométrie - Chroniques de niveaux des nappes"""
+    """Ingests piezometry chroniques data using dlt."""
+
     return ingest_dlt(context, "configs/hubeau/piezometry_chroniques.yml")
 
 
-# ====================================
-# ASSETS QUALITÉ DES EAUX
-# ====================================
-
-@asset(required_resource_keys={"s3"})
+@asset(group_name="hubeau_quality_rivers", partitions_def=YEARLY_PARTITIONS)
 def quality_rivers_analyses(context: AssetExecutionContext) -> Dict[str, Any]:
-    """🏞️ Qualité Cours d'Eau - Analyses physico-chimiques"""
+    """Ingests superficial waterbodies quality analyses data using dlt."""
+
     return ingest_dlt(context, "configs/hubeau/quality_rivers_analyses.yml")
 
 
-@asset(required_resource_keys={"s3"})
+@asset(group_name="hubeau_quality_groundwater", partitions_def=YEARLY_PARTITIONS)
 def quality_groundwater_analyses(context: AssetExecutionContext) -> Dict[str, Any]:
-    """💧 Qualité Nappes - Analyses eaux souterraines"""
+    """Ingests groundwater quality analyses data using dlt."""
+
     return ingest_dlt(context, "configs/hubeau/quality_groundwater_analyses.yml")
 
 
-# ====================================
-# ASSETS ÉCOULEMENT
-# ====================================
-
-@asset(required_resource_keys={"s3"})
+@asset(group_name="hubeau_ecoulement", partitions_def=YEARLY_PARTITIONS)
 def ecoulement_observations(context: AssetExecutionContext) -> Dict[str, Any]:
-    """🌊 Écoulement - Observations ONDE (Observatoire National Des Étiages)"""
+    """Ingests ecoulement observations data using dlt."""
+
     return ingest_dlt(context, "configs/hubeau/ecoulement_observations.yml")
 
 
-# ====================================
-# ASSETS PRÉLÈVEMENTS
-# ====================================
-
-@asset(required_resource_keys={"s3"})
+@asset(group_name="hubeau_prelevements", partitions_def=YEARLY_PARTITIONS)
 def prelevements_chroniques(context: AssetExecutionContext) -> Dict[str, Any]:
-    """💧 Prélèvements - Chroniques de prélèvement (limite 20k stricte)"""
+    """Ingests prelevements chroniques data using dlt."""
+
     return ingest_dlt(context, "configs/hubeau/prelevements_chroniques.yml")
 
 
-# ====================================
-# ASSETS TEMPÉRATURE
-# ====================================
-
-@asset(required_resource_keys={"s3"})
+@asset(group_name="hubeau_temperature", partitions_def=YEARLY_PARTITIONS)
 def temperature_chroniques(context: AssetExecutionContext) -> Dict[str, Any]:
-    """🌡️ Température - Chroniques de température (station×mois systématique)"""
+    """Ingests temperature chroniques data using dlt."""
+
     return ingest_dlt(context, "configs/hubeau/temperature_chroniques.yml")
 
 
-# ====================================
-# EXPORT DES ASSETS
-# ====================================
+@asset(group_name="hubeau_temperature")
+def temperature_stations_reference(context: AssetExecutionContext) -> Dict[str, Any]:
+    """Ingests temperature stations reference data using dlt (pas de partition)."""
+
+    return ingest_dlt(context, "configs/reference/temperature_stations.yml")
+
 
 __all__ = [
     "ingest_dlt",
-    # Hydrobiologie
     "hydrobio_taxons",
     "hydrobio_indices",
-    # Hydrométrie
     "hydrometry_observations",
-    # Piézométrie
     "piezometry_chroniques",
-    # Qualité
     "quality_rivers_analyses",
     "quality_groundwater_analyses",
-    # Écoulement
     "ecoulement_observations",
-    # Prélèvements
     "prelevements_chroniques",
-    # Température
     "temperature_chroniques",
+    "temperature_stations_reference",
 ]

--- a/src/hubeau_pipeline/definitions.py
+++ b/src/hubeau_pipeline/definitions.py
@@ -5,16 +5,16 @@ Définitions Dagster centrales - Point d'entrée de l'application
 from dagster import Definitions
 
 # Import des assets
-from hubeau_pipeline.assets import all_assets
+from .assets import all_assets
 
-# Import des jobs  
-from hubeau_pipeline.jobs import all_jobs
+# Import des jobs
+from .jobs import all_jobs
 
 # Import des schedules
-from hubeau_pipeline.schedules import all_schedules
+from .schedules import all_schedules
 
 # Import des resources
-from hubeau_pipeline.resources import RESOURCES
+from .resources import RESOURCES
 
 # Définitions centrales
 defs = Definitions(

--- a/tests/test_end_to_end_small.py
+++ b/tests/test_end_to_end_small.py
@@ -16,12 +16,22 @@ class DummyHttpClient:
         self.cfg = cfg
         self.calls = []
 
-    def get(self, path: str, params: Dict[str, Any]):
+    def request(self, method: str, path: str, **kwargs):
+        params = kwargs.get("params") or kwargs.get("json_body") or {}
         self.calls.append((path, params))
         return {"data": [{"id_taxon": 1, "code_station": "A", "date_prelevement": "2024-01-01"}]}
 
     def extract_records(self, payload: Dict[str, Any], records_path: str):
         return payload["data"]
+
+    def close(self):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
 
 def test_pipeline_runs(tmp_path, monkeypatch):
     monkeypatch.setenv("DESTINATION__FILESYSTEM__PATH", str(tmp_path))

--- a/tests/test_http_retry.py
+++ b/tests/test_http_retry.py
@@ -26,10 +26,13 @@ class DummyClient:
         self.responses = responses
         self.calls = 0
 
-    def get(self, *args, **kwargs):
+    def request(self, *args, **kwargs):
         response = self.responses[self.calls]
         self.calls += 1
         return response
+
+    def close(self):
+        return None
 
 
 def test_retry_on_429(monkeypatch):
@@ -39,9 +42,35 @@ def test_retry_on_429(monkeypatch):
     http_client = HttpClient(cfg, client=client)
     http_client.bucket.consume = MagicMock()  # avoid sleeping
     http_client.bucket.consume.side_effect = lambda *args, **kwargs: None
+    monkeypatch.setattr("pipelines.dlt.http_client.time.sleep", lambda *_args, **_kwargs: None)
     data = http_client.get("/endpoint", params={})
     assert client.calls == 2
     assert data == {"data": []}
+
+
+def test_request_stops_after_max_attempts(monkeypatch):
+    error = httpx.TransportError("boom")
+
+    class FailingClient:
+        def __init__(self):
+            self.calls = 0
+
+        def request(self, *args, **kwargs):
+            self.calls += 1
+            raise error
+
+        def close(self):
+            return None
+
+    failing_client = FailingClient()
+    cfg = {"base_url": "https://example.com", "max_attempts": 3}
+    http_client = HttpClient(cfg, client=failing_client)
+    http_client.bucket.consume = MagicMock(side_effect=lambda *args, **kwargs: None)
+    monkeypatch.setattr("pipelines.dlt.http_client.time.sleep", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(httpx.TransportError):
+        http_client.request("GET", "/endpoint", params={})
+    assert failing_client.calls == 3
 
 
 def test_extract_records_jsonpath():


### PR DESCRIPTION
## Summary
- rebuild the Hub'Eau dlt pipeline runner to normalise configuration handling, support arbitrary HTTP methods, and provide sane defaults for filesystem destinations and state persistence
- rework the Dagster dlt assets to share a partition-aware ingestion helper with MinIO credential handling and slice updates derived from partition keys
- switch the central Dagster definitions to package-relative imports to reflect the project layout

## Testing
- pytest tests/test_http_retry.py tests/test_end_to_end_small.py tests/test_hubeau_generic_utils.py tests/test_slicing.py -q

------
https://chatgpt.com/codex/tasks/task_e_68de96a2b2488327984315297373f192