### PR TITLE
Keep unlimited truncation default for Hub’Eau pipelines

### DIFF
--- a/pipelines/dlt/schema.py
+++ b/pipelines/dlt/schema.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, ConfigDict
 
 
 class PaginationConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     type: str = Field(default="page")
     page_param: str = Field(default="page")
     page_size_param: str = Field(default="size")
@@ -15,7 +17,14 @@ class PaginationConfig(BaseModel):
 
 
 class SlicerConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     mode: str
+    param: str | None = None
+    values: list[str] | None = None
+    reference: Dict[str, Any] | None = None
+    stations: list[str] | None = None
+    campaigns: list[Any] | None = None
     start_param: str | None = None
     end_param: str | None = None
     window_days: int | None = Field(default=None, ge=1)
@@ -31,6 +40,8 @@ class SlicerConfig(BaseModel):
 
 
 class ConfigModel(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     name: str
     source: str
     base_url: str

--- a/pipelines/dlt/slicing.py
+++ b/pipelines/dlt/slicing.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Iterable, Iterator, List, Optional
 
 import yaml
 
-TRUNCATION_DEFAULT = float('inf')  # Par défaut, pas de troncature (récupère tout)
+TRUNCATION_DEFAULT = float("inf")  # Par défaut, pas de troncature (récupère toutes les données)
 
 
 @dataclass

--- a/tests/test_slicing.py
+++ b/tests/test_slicing.py
@@ -35,8 +35,14 @@ def test_build_datetime_slices(monkeypatch, datetime_cfg):
 
 
 def test_needs_truncation_default():
-    assert needs_truncation(25_000, {})
-    assert not needs_truncation(1_000, {})
+    assert not needs_truncation(25_000, {})
+
+
+def test_needs_truncation_with_threshold():
+    cfg = {"fallbacks": {"truncation_threshold": 10_000}}
+    assert needs_truncation(10_000, cfg)
+    assert needs_truncation(25_000, cfg)
+    assert not needs_truncation(9_999, cfg)
 
 
 def test_fallback_day(monkeypatch, datetime_cfg):


### PR DESCRIPTION
## Summary
- allow the DLT config schema to keep slicer values and related metadata so dept-based slicing works again
- retain an unlimited truncation threshold by default so pipelines fetch every record unless a config opts in

## Testing
- pytest tests/test_slicing.py

------
https://chatgpt.com/codex/tasks/task_e_68df870975f8832791e0d91ebf6c02a9