### PR TITLE
Fix hydrometry ingestion to clean null primary keys early

### DIFF
--- a/pipelines/dlt/hubeau_generic.py
+++ b/pipelines/dlt/hubeau_generic.py
@@ -219,6 +219,12 @@ def hubeau_source(
                     total_requests_made += 1
                     
                     batch = list(http_client.extract_records(payload, resolved_cfg.get("records_path")))
+
+                    # Nettoyer immédiatement les champs critiques pour éviter toute valeur NULL
+                    # d'atteindre les étapes ultérieures (ex: troncature sans retraitement).
+                    for record in batch:
+                        _clean_critical_fields(record, resolved_cfg)
+
                     buffered_batches.append(batch)
                     slice_records += len(batch)
                     
@@ -277,9 +283,6 @@ def hubeau_source(
                 # Traitement des records
                 for batch in buffered_batches:
                     for record in batch:
-                        # Clean up NULL values in critical fields for all APIs
-                        _clean_critical_fields(record, resolved_cfg)
-                        
                         record["_slice_id"] = slice_obj.slice_id
                         record["_scope"] = slice_obj.scope
                         yield record


### PR DESCRIPTION
## Summary
- clean Hub'Eau records immediately after extraction so null primary keys are replaced before any truncation branches yield data
- keep slice metadata enrichment unchanged while ensuring previously null `code_station` values are substituted from available fallbacks

## Testing
- pytest tests/test_end_to_end_small.py

------
https://chatgpt.com/codex/tasks/task_e_68df8a7f19048327bd04aacff9591aff